### PR TITLE
add hexo-toc plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea/
 node_modules/
 *.log
 db.json

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -304,3 +304,10 @@
     - tag
     - spotify
     - widget
+- name: hexo-toc
+  description: Insert a TOC before markdown be rendered when a placeholder(<!-- toc -->) found in the markdown.
+  link: https://github.com/bubkoo/hexo-toc
+  tags:
+    - toc
+    - filter
+    - markdown


### PR DESCRIPTION
Plugin link: [hexo-toc](https://github.com/bubkoo/hexo-toc)

Insert a markdown TOC(Table Of Content) before posts be rendered. 

Unlike the native [`toc`](http://hexo.io/docs/helpers.html#toc) helper, this plugin will inject a TOC only when a placeholder(`<!-- toc -->`) found in the raw markdown files. And the TOC will be injected after the placeholder. 

All you need to do is placing a placeholder(`<!-- toc -->`) in your post when and where needed. 

**Note:** this plugin will not mangle your posts(markdown files), so you can use it bold.