### PR TITLE
Add hexo-front-matter-excerpt to Hexo official plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -354,3 +354,9 @@
     - image
     - css
     - js
+- name: hexo-front-matter-excerpt
+  description: Write post excerpts using YAML front matter.
+  link: https://github.com/lalunamel/hexo-front-matter-excerpt
+  tags:
+    - excerpt
+    - front-matter


### PR DESCRIPTION
Hello,

I'd like to add my plugin to the Hexo plugins list.

The plugin is called `hexo-front-matter-excerpt` and it allows writing post excerpts in the yaml front-matter of a post.