### PR TITLE
Add hexo-github tag plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -360,3 +360,12 @@
   tags:
     - excerpt
     - front-matter
+- name: hexo-github
+  description: Display a GitHub repositoy badge with timeline in your post to keep track of version difference.
+  link: https://github.com/akfish/hexo-github
+  tags:
+    - tag
+    - timeline
+    - badge
+    - github
+    - version control


### PR DESCRIPTION
**hexo-github**
Display a GitHub repositoy badge with timeline in your post to keep track of version difference.
https://github.com/akfish/hexo-github