### PR TITLE
added the hexo-tag-googlemaps plugin to the plugin list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -369,3 +369,15 @@
     - badge
     - github
     - version control
+- name: hexo-tag-googlemaps
+  description: A hexo tag for google maps. Does much more than a simple embedded iFrame
+  link: https://github.com/the-simian/hexo-tag-googlemaps
+  tags:
+    - tag
+    - googlemaps
+    - map
+    - latitude
+    - longitude
+    - markers
+    
+    


### PR DESCRIPTION
"The google maps tag plugin for hexo is designed to be a way to add simple maps to your hexo site. The main tag, called googlemaps requires an endtag called endgooglemaps"