### PR TITLE
Adding the hexo-tag-deezer music widget plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -331,6 +331,7 @@
   tags:
     - tag
     - spotify
+    - music
     - widget
 - name: hexo-tag-plantuml
   description: hexo-tag-plantuml is a tag plugin of Hexo. It can work with plantuml to draw uml.
@@ -407,3 +408,11 @@
     - tag
     - googlecharts
     - chart
+- name: hexo-tag-deezer
+  description: Tag for showing Deezer track widget on page.
+  link: https://github.com/OdinsHat/hexo-tag-deezer
+  tags:
+    - tag
+    - deezer
+    - music
+    - widget


### PR DESCRIPTION
Similar to the Spotify widget plugin but for the Deezer service. Example of it working is given on the plugin repo.