### PR TITLE
Added hexo-more-css.

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -5,6 +5,14 @@
     - wordcount
     - count
     - words
+- name: hexo-more-css
+  description: Compress CSS with more-css.
+  link: https://github.com/vseventer/hexo-more-css
+  tags:
+    - css
+    - filter
+    - minify
+    - more-css
 - name: hexo-ruby-character
   description: Ruby charater tag for Hexo, like <ruby>博客<rp> (</rp><rt>bó kè</rt><rp>) </rp></ruby>.
   link: https://github.com/JamesPan/hexo-ruby-character


### PR DESCRIPTION
Compress CSS with [more-css](https://github.com/army8735/more). This is an alternative for [hexo-clean-css](https://github.com/hexojs/hexo-clean-css), with better results in some cases, see the [CSS minification benchmark](https://goalsmashers.github.io/css-minification-benchmark/).