### PR TITLE
Add search.xml generator.

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -198,6 +198,12 @@
     - generator
     - feed
     - rss
+- name: hexo-generator-search
+  description: Search data generator for Hexo.
+  link: https://github.com/PaicHyperionDev/hexo-generator-search
+  tags:
+    - generator
+    - search
 - name: hexo-renderer-stylus
   description: Stylus renderer for Hexo.
   link: https://github.com/hexojs/hexo-renderer-stylus


### PR DESCRIPTION
Generate search data for Hexo 3.0.This plugin is used to generator a search.xml file.The file contains the main data of your blog so that you can use the data to finish a search function for your blog.