### PR TITLE
Clarify expected format of config values

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -10,8 +10,8 @@ Setting | Description
 `subtitle` | The subtitle of your website
 `description` | The description of your website
 `author` | Your name
-`language` | The language of your website
-`timezone` | The timezone of your website. Hexo uses the setting on your computer by default. You can find the list of available timezones [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+`language` | The language of your website. Use a [2-lettter ISO-639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). Default is `en`.
+`timezone` | The timezone of your website. Hexo uses the setting on your computer by default. You can find the list of available timezones [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Some examples are `America/New_York`, `Japan`, and `UTC`.
 
 ### URL
 


### PR DESCRIPTION
When I first read this on the website I was confused by the overload of data from the [timezone][1] option and lack of info on the language option.

I added a Wikipedia link to the proper two digit language codes and the [default][2] of `en`.

[1]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
[2]: https://github.com/hexojs/hexo/blob/f01a9aa3db9dc5b52d056c7467186fa5f33c5857/test/scripts/filters/i18n_locals.js#L12-L13