### PR TITLE
Add hexo-generator-json-content to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -507,3 +507,13 @@
     - tag
     - bilibili
     - video
+- name: hexo-generator-json-content
+  description: Generate a JSON file for generic use or consumption with the contents of posts and pages. Useful for AJAX search or content API.
+  link: https://github.com/alexbruno/hexo-generator-json-content
+  tags:
+    - generator
+    - content
+    - json
+    - data
+    - search
+    - api


### PR DESCRIPTION
I created a plugin to generate a JSON file with contents of pages and posts and some site meta data.

I think it's useful for AJAX search or API content. So I added it to the site plugins list.