### PR TITLE
Edited docs for spelling and grammar

### DIFF
--- a/source/docs/asset-folders.md
+++ b/source/docs/asset-folders.md
@@ -1,16 +1,16 @@
 title: Asset Folders
 ---
-Assets are non-post files in `source` folder, such as images, CSS or JavaScript files. Hexo provides a more convenient way to manage assets. To enable this, modify `post_asset_folder` setting.
+Assets are non-post files in the `source` folder, such as images, CSS or JavaScript files. Hexo provides a more convenient way to manage these assets. To enable asset management, set the `post_asset_folder` setting to true.
 
 ``` yaml
 post_asset_folder: true
 ```
 
-Once `post_asset_folder` setting is enabled, Hexo will create a folder with the same name as the new post. You can put all assets related to the post into the folder. So that you can use them more easily.
+When asset folder management is enabled, every time you create a new post, Hexo will create a folder with the same name. Put all your assets that are related to a certain post into the associated folder to use them in an easier and more convenient way.
 
 ## Tag Plugins
 
-Several tag plugins are added in Hexo 3 for you to include assets in posts more easily.
+The release of Hexo 3 saw several new tag plugins added which enable you to reference your assets more easily in posts.
 
 ```
 {% asset_path slug %}

--- a/source/docs/data-files.md
+++ b/source/docs/data-files.md
@@ -1,6 +1,6 @@
 title: Data Files
 ---
-Sometimes you may need to use some data in templates which is not in posts, or you want to reuse these data. Then you can try the new "**Data files**" introducing in Hexo 3. This feature loads YAML or JSON files in `source/_data` folder so you can use them in your site.
+Sometimes you may need to use some data in templates which is not directly available in your posts, or you want to reuse the data elsewhere. For such use cases, Hexo 3 introduced the new **Data files**. This feature loads YAML or JSON files in `source/_data` folder so you can use them in your site.
 
 For example, add `menu.yml` in `source/_data` folder.
 

--- a/source/docs/deployment.md
+++ b/source/docs/deployment.md
@@ -1,19 +1,19 @@
 title: Deployment
 ---
-Hexo provides a fast and easy way for deployment. You only need one command to deploy your site to servers.
+Hexo provides a fast and easy deployment strategy. You only need one single command to deploy your site to your servers.
 
 ``` bash
 $ hexo deploy
 ```
 
-Before we start, you have to modify settings in `_config.yml`. A valid deployment setting must come with `type` field. For example:
+Before your first deployment, you will have to modify some settings in `_config.yml`. A valid deployment setting must have a `type` field. For example:
 
 ``` yaml
 deploy:
   type: git
 ```
 
-You can use multiple deployers. Hexo will execute each deployer in sequence.
+You can use multiple deployers. Hexo will execute each deployer in order.
 
 ``` yaml
 deploy:
@@ -44,7 +44,7 @@ deploy:
 Option | Description
 --- | ---
 `repo` | GitHub repository URL
-`branch` | Branch name. The deployer will detect branch automatically if you are using GitHub or GitCafe.
+`branch` | Branch name. The deployer will automatically detect the branch automatically if you are using GitHub or GitCafe.
 `message` | Customize commit message (Default to `Site updated: {% raw %}{{ now('YYYY-MM-DD HH:mm:ss') }}{% endraw %}`)
 
 ## Heroku
@@ -159,7 +159,7 @@ Option | Description | Default
 
 ## Other Methods
 
-All generated files are saved in `public` folder. You can copy it to wherever you like.
+All generated files are saved in the `public` folder. You can copy them to wherever you like.
 
 [hexo-deployer-git]: https://github.com/hexojs/hexo-deployer-git
 [hexo-deployer-heroku]: https://github.com/hexojs/hexo-deployer-heroku

--- a/source/docs/front-matter.md
+++ b/source/docs/front-matter.md
@@ -20,7 +20,7 @@ date: 2013/7/13 20:46:25
 
 Setting | Description | Default
 --- | --- | ---
-`layout` | Layout | 
+`layout` | Layout |
 `title` | Title |
 `date` | Published date | File created date
 `updated` | Updated date | File updated date
@@ -31,7 +31,7 @@ Setting | Description | Default
 
 #### Categories & Tags
 
-Categories and tags are only supported in posts. Categories apply to posts in order, creating a hierarchy of classifications and sub-classifications; tags sit at the same level with each other and do not care about how they are ordered.
+Only posts support the use of categories and tags. Categories apply to posts in order, resulting in a hierarchy of classifications and sub-classifications. Tags are all defined on the same hierarchical level so the order in which they appear is not important.
 
 **Example**
 

--- a/source/docs/generating.md
+++ b/source/docs/generating.md
@@ -1,6 +1,6 @@
 title: Generating
 ---
-Generate static files with Hexo is quite easy and fast.
+Generating static files with Hexo is quite easy and fast.
 
 ``` bash
 $ hexo generate
@@ -8,7 +8,7 @@ $ hexo generate
 
 ### Watch for File Changes
 
-Hexo can watch for file changes and regenerate files immediately. Hexo will compare SHA1 checksum of files and only write if files changed.
+Hexo can watch for file changes and regenerate files immediately. Hexo will compare the SHA1 checksum of your files and only write if file changes are detected.
 
 ``` bash
 $ hexo generate --watch
@@ -16,7 +16,7 @@ $ hexo generate --watch
 
 ### Deploy After Generating
 
-To deploy after generating, you can run one of the following commands. Both of them are equaled.
+To deploy after generating, you can run one of the following commands. There is no difference between the two.
 
 ``` bash
 $ hexo generate --deploy

--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -23,9 +23,7 @@ Returns the relative URL from `from` to `to`.
 ### gravatar
 
 Inserts a Gravatar image.
-The [options] paramater can be excluded completely and you will get the default options.
-It can be a number which will then be passed on as the size paramater to Gravatar.
-Otherwise it can be an object which will be converted into a query string of parameters for Gravatar.
+If you don't specify the [options] parameter, the default options will apply. Otherwise, you can set it to a number which will then be passed on as the size parameter to Gravatar. Finally, if you set it to an object, it will be converted into a query string of parameters for Gravatar.
 
 ``` js
 <%- gravatar(email, [options]);
@@ -48,7 +46,7 @@ Otherwise it can be an object which will be converted into a query string of par
 
 ### css
 
-Loads CSS files. `path` can be an array or a string. If `path` isn't prefixed with `/` or any protocol, it'll be prefixed with root URL. If you didn't add extension name `.css` after `path`, it'll be added.
+Loads CSS files. `path` can be an array or a string. If `path` isn't prefixed with `/` or any protocol, it'll get prefixed with the root URL. If you didn't add the `.css` extension after `path`, it will be added automatically.
 
 ``` js
 <%- css(path, ...) %>
@@ -67,7 +65,7 @@ Loads CSS files. `path` can be an array or a string. If `path` isn't prefixed wi
 
 ### js
 
-Loads JavaScript files. `path` can be an array or a string. If `path` isn't prefixed with `/` or any protocol, it'll be prefixed with root URL. If you didn't add extension name `.js` after `path`, it'll be added.
+Loads JavaScript files. `path` can be an array or a string. If `path` isn't prefixed with `/` or any protocol, it'll get prefixed with the root URL. If you didn't add the `.js` extension after `path`, it will be added automatically.
 
 ``` js
 <%- js(path, ...) %>
@@ -126,7 +124,7 @@ Option | Description
 `subject` | Mail subject
 `cc` | CC
 `bcc` | BCC
-`body` | Mail contents
+`body` | Mail content
 
 **Examples:**
 
@@ -140,7 +138,7 @@ Option | Description
 
 ### image_tag
 
-Inserts a image.
+Inserts an image.
 
 ``` js
 <%- image_tag(path, [options]) %>
@@ -203,7 +201,7 @@ Check whether the current page is a post.
 
 ### is_archive
 
-Check whether the current page is a archive page.
+Check whether the current page is an archive page.
 
 ``` js
 <%- is_archive() %>
@@ -241,7 +239,7 @@ Check whether the current page is a tag page.
 <%- is_tag() %>
 ```
 
-## String Manipulating
+## String Manipulation
 
 ### trim
 

--- a/source/docs/internationalization.md
+++ b/source/docs/internationalization.md
@@ -1,6 +1,6 @@
 title: Internationalization (i18n)
 ---
-You can use internationalization to present your site in different languages. Please edit `language` setting in `_config.yml`. This is your default language. You can also set multiple languages to modify the order of default languages.
+You can use internationalization to present your site in different languages. The default language is set by modifying the `language` setting in `_config.yml`. You can also set multiple languages and modify the order of default languages.
 
 ``` yaml
 language: zh-tw
@@ -12,11 +12,11 @@ language:
 
 ### Language Files
 
-Language files can be a YAML or JSON file. They should be put into the `languages` folder in the theme. You can use [printf format](https://github.com/alexei/sprintf.js) in language files.
+Language files can be YAML or JSON files. You should put them into the `languages` folder in the theme. There is support for the [printf format](https://github.com/alexei/sprintf.js) in language files.
 
 ### Templates
 
-Use `__` or `_p` helpers in templates to get the translated strings. The former is for normal usage and the letter is for plural strings. For example:
+Use `__` or `_p` helpers in templates to get the translated strings. The former is for normal usage and the latter is for plural strings. For example:
 
 ``` yaml en.yml
 index:
@@ -38,13 +38,13 @@ index:
 
 ### Path
 
-You can set the language of pages in front-matter, or modify `i18n_dir` setting in `_config.yml` to enable Hexo detect automatically.
+You can set the language of pages in front-matter, or modify the `i18n_dir` setting in `_config.yml` to enable automatic detection by Hexo.
 
 ``` yaml
 i18n_dir: :lang
 ```
 
-The default value of `i18n_dir` setting is `:lang`, which means Hexo will detect the language with the first segment of URL. For example:
+The default value of `i18n_dir` setting is `:lang`, which means that Hexo will detect the language within the first segment of URL. For example:
 
 ``` plain
 /index.html => en
@@ -52,4 +52,4 @@ The default value of `i18n_dir` setting is `:lang`, which means Hexo will detect
 /zh-tw/index.html => zh-tw
 ```
 
-The string will only be served as a language when the language file exists. So `archives` in `/archives/index.html` (example 2) is not served as a language.
+The string will only be served as a language when the language file exists. So `archives` in `/archives/index.html` (example 2) will not get served as a language.

--- a/source/docs/permalinks.md
+++ b/source/docs/permalinks.md
@@ -15,9 +15,9 @@ Variable | Description
 `:i_day` | Published day of posts (Without leading zeros)
 `:title` | Filename
 `:id` | Post ID
-`:category` | Categories. If the post is uncategorized, it'll be `default_category` setting.
+`:category` | Categories. If the post is uncategorized, it will use the `default_category` value.
 
-You can define the default value of each variable in the permalink in `permalink_defaults` setting:
+You can define the default value of each variable in the permalink through the `permalink_defaults` setting:
 
 ``` yaml
 permalink_defaults:
@@ -26,7 +26,7 @@ permalink_defaults:
 
 ### Examples
 
-Given a post named `hello-world.md` in `source/_posts` folder with the following content.
+Given a post named `hello-world.md` in the `source/_posts` folder with the following content.
 
 ``` yaml
 title: Hello World
@@ -44,7 +44,7 @@ Setting | Result
 
 ### Multi-language Support
 
-To create a multi-language site, you can modify `new_post_name` and `permalink` setting like this:
+To create a multi-language site, you can modify the `new_post_name` and `permalink` settings like this:
 
 ``` yaml
 new_post_name: :lang/:title.md

--- a/source/docs/plugins.md
+++ b/source/docs/plugins.md
@@ -1,16 +1,16 @@
 title: Plugins
 ---
-Hexo has a powerful plugin system, which makes you easy to extend functions without modifying source code of the core module. There're two kinds of plugins in Hexo:
+Hexo has a powerful plugin system, which makes it easy to extend functions without modifying the source code of the core module. There are two kinds of plugins in Hexo:
 
 ### Script
 
-If your code is simple, it's recommended to use a script. All you need to do is putting JavaScript files in `scripts` folder and they'll be loaded once Hexo is initialized.
+If your plugin is relatively simple, it's recommended to use a script. All you need to do is put your JavaScript files in the `scripts` folder and Hexo will load them during initialization.
 
 ### Plugin
 
-If your code is complicated or you want to publish it to NPM registry, it's recommended to use a plugin. First, create a folder in `node_modules` folder. The name of the folder must be started with `hexo-` so it could be loaded by Hexo.
+If your code is complicated or if you want to publish it to the NPM registry, we recommend using a plugin. First, create a folder in the `node_modules` folder. The name of this folder must begin with `hexo-` or Hexo will ignore it.
 
-The folder must be contained at least 2 files: One is the main program and the other is `package.json` describing the purpose and the dependencies of the plugin.
+Your new folder must contain at least two files: one containing the actual JavaScript code and one `package.json` file that describes the purpose of the plugin and sets its dependencies.
 
 ``` plain
 .
@@ -18,7 +18,7 @@ The folder must be contained at least 2 files: One is the main program and the o
 └── package.json
 ```
 
-You should at least describe `name`, `version`, `main` in `package.json`. For example:
+At the very least, you should set the `name`, `version` and `main` entries in `package.json`. For example:
 
 ``` json package.json
 {
@@ -30,7 +30,7 @@ You should at least describe `name`, `version`, `main` in `package.json`. For ex
 
 ### Tools
 
-You can make use of the official tools provided by Hexo to accelerate development: 
+You can make use of the official tools provided by Hexo to accelerate development:
 
 - [hexo-fs]：File IO
 - [hexo-util]：Utilities
@@ -39,7 +39,7 @@ You can make use of the official tools provided by Hexo to accelerate developmen
 
 ### Publishing
 
-Once your plugin has been done, you can consider to publish it to [plugin list](/plugins) to make more people use your plugin. The steps to publish a plugin is very simliar to [updating documentation](contributing.html#Updating_Documentation).
+When your plugin is ready, you may consider publishing it to the [plugin list](/plugins) to invite other people to start using it. Publishing your own plugins is very similar to [updating documentation](contributing.html#Updating_Documentation).
 
 1. Fork [hexojs/site]
 2. Clone the repository to your computer and install dependencies.
@@ -49,7 +49,7 @@ Once your plugin has been done, you can consider to publish it to [plugin list](
     $ cd site
     $ npm install
     {% endcode %}
-    
+
 3. Edit `source/_data/_plugins.yml` and add your plugin. For example:
 
     {% code %}
@@ -61,7 +61,7 @@ Once your plugin has been done, you can consider to publish it to [plugin list](
         - server
         - console
     {% endcode %}
-    
+
 4. Push the branch.
 5. Create a pull request and describe the change.
 

--- a/source/docs/server.md
+++ b/source/docs/server.md
@@ -2,19 +2,19 @@ title: Server
 ---
 ## [hexo-server]
 
-Server was separated from the main module in Hexo 3. You have to install [hexo-server] before start using.
+With the release of Hexo 3, the server has been separated from the main module. To start using the server, you will first have to install [hexo-server].
 
 ``` bash
 $ npm install hexo-server --save
 ```
 
-Once the server is installed, run the following command to start the server. Your website will run at `http://localhost:4000` by default. When server is running, Hexo will watch file changes and update automatically. You don't need to restart the server.
+Once the server has been installed, run the following command to start the server. Your website will run at `http://localhost:4000` by default. When the server is running, Hexo will watch for file changes and update automatically so it's not necessary to manually restart the server.
 
 ``` bash
 $ hexo server
 ```
 
-If you want to modify the port or encounter `EADDRINUSE` error. You can add `-p` option to set other port.
+If you want to change the port or if you're encountering `EADDRINUSE` errors, use the `-p` option to set a different port.
 
 ``` bash
 $ hexo server -p 5000
@@ -22,7 +22,7 @@ $ hexo server -p 5000
 
 ### Static Mode
 
-In static mode, only files in `public` folder will be served and file watching is disabled. You have to run `hexo generate` before starting the server. Usually used in production.
+In static mode, only files in the `public` folder will be served and file watching is disabled. You have to run `hexo generate` before starting the server. Usually used in production.
 
 ``` bash
 $ hexo server -s
@@ -55,7 +55,7 @@ $ cd ~/.pow
 $ ln -s /path/to/myapp
 ```
 
-Your website will be up and running at `http://myapp.dev`. The URL is based on the name of symlink.
+Your website will be up and running at `http://myapp.dev`. The URL is based on the name of the symlink.
 
 [hexo-server]: https://github.com/hexojs/hexo-server
 [Pow]: http://pow.cx/

--- a/source/docs/tag-plugins.md
+++ b/source/docs/tag-plugins.md
@@ -1,10 +1,10 @@
 title: Tag Plugins
 ---
-Tag plugins are different from tags in posts. They're ported from Octopress and can help you insert specific contents in posts quickly.
+Tag plugins are different from post tags. They are ported from Octopress and provide a useful way for you to quickly add specific content to your posts.
 
 ## Block Quote
 
-Inserts quotes with author, source and title in posts.
+Perfect for adding quotes to your post, with optional author, source and title information.
 
 **Alias:** quote
 
@@ -14,9 +14,9 @@ content
 {% endblockquote %}
 ```
 
-### Example
+### Examples
 
-**No arguments given. Only output plain blockquote**
+**No arguments. Plain blockquote.**
 
 ```
 {% blockquote %}
@@ -66,7 +66,7 @@ Every interaction is both precious and an opportunity to delight.
 
 ## Code Block
 
-Inserts code snippets in posts.
+Useful feature for adding code snippets to your post.
 
 **Alias:** code
 
@@ -76,9 +76,9 @@ code snippet
 {% endcodeblock %}
 ```
 
-### Example
+### Examples
 
-**A normal code block**
+**A plain code block**
 
 ```
 {% codeblock %}
@@ -90,7 +90,7 @@ alert('Hello World!');
 alert('Hello World!');
 {% endcodeblock %}
 
-**Specify language**
+**Specifying the language**
 
 ```
 {% codeblock lang:objc %}
@@ -102,7 +102,7 @@ alert('Hello World!');
 [rectangle setX: 10 y: 10 width: 20 height: 20];
 {% endcodeblock %}
 
-**Add caption to code block**
+**Adding a caption to the code block**
 
 ```
 {% codeblock Array.map %}
@@ -114,7 +114,7 @@ array.map(callback[, thisArg])
 array.map(callback[, thisArg])
 {% endcodeblock %}
 
-**Add caption with an optional URL**
+**Adding a caption and a URL**
 
 ```
 {% codeblock _.compact http://underscorejs.org/#compact Underscore.js %}
@@ -130,17 +130,17 @@ _.compact([0, 1, false, 2, '', 3]);
 
 ## Backtick Code Block
 
-This plugin is same as code block, but in backtick style.
+This is identical to using a code block, but instead uses three backticks to delimit the block.
 
-{% code %}
-``` [language] [title] [url] [link text]
+{% raw %}
+&#96`` [language] [title] [url] [link text]
 code snippet
-```
-{% endcode %}
+&#96;``
+{% endraw %}
 
 ## Pull Quote
 
-This plugin helps you insert a pull quote in posts.
+To add pull quotes to your posts:
 
 ```
 {% pullquote [class] %}
@@ -150,7 +150,7 @@ content
 
 ## jsFiddle
 
-Embeds jsFiddle snippets in posts.
+To embed a jsFiddle snippet:
 
 ```
 {% jsfiddle shorttag [tabs] [skin] [width] [height] %}
@@ -158,7 +158,7 @@ Embeds jsFiddle snippets in posts.
 
 ## Gist
 
-Embeds Gist snippets in posts.
+To embed a Gist snippet:
 
 ```
 {% gist gist_id [filename] %}
@@ -166,7 +166,7 @@ Embeds Gist snippets in posts.
 
 ## iframe
 
-Embeds an iframe in posts.
+To embed an iframe:
 
 ```
 {% iframe url [width] [height] %}
@@ -174,7 +174,7 @@ Embeds an iframe in posts.
 
 ## Image
 
-Inserts an image in posts with specified size.
+Inserts an image with specified size.
 
 ```
 {% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
@@ -196,9 +196,9 @@ Inserts code snippets in `source/downloads/code` folder.
 {% include_code [title] [lang:language] path/to/file %}
 ```
 
-## Youtube
+## YouTube
 
-Inserts a Youtube video in posts.
+Inserts a YouTube video.
 
 ```
 {% youtube video_id %}
@@ -206,7 +206,7 @@ Inserts a Youtube video in posts.
 
 ## Vimeo
 
-Inserts a Vimeo video in posts.
+Inserts a Vimeo video.
 
 ```
 {% vimeo video_id %}
@@ -214,7 +214,7 @@ Inserts a Vimeo video in posts.
 
 ## Include Posts
 
-Include the link of other posts.
+Include links to other posts.
 
 ```
 {% post_path slug %}
@@ -223,7 +223,7 @@ Include the link of other posts.
 
 ## Include Assets.
 
-Include the assets of posts.
+Include post assets.
 
 ```
 {% asset_path slug %}
@@ -233,7 +233,7 @@ Include the assets of posts.
 
 ## Raw
 
-If there're some contents can't be processed in posts, you can wrap it with `raw` tag to avoid rendering errors.
+If certain content is causing processing issues in your posts, wrap it with the `raw` tag to avoid rendering errors.
 
 ```
 {% raw %}

--- a/source/docs/templates.md
+++ b/source/docs/templates.md
@@ -1,10 +1,10 @@
 title: Templates
 ---
-Templates decide the presentation of your website. Every theme should contain at least a `index` template. The following is the corresponding template for each pages.
+Templates define the presentation of your website by describing what each page should look like. The table below shows the corresponding template for every available page. At the very least, a theme should contain an `index` template.
 
 Template | Page | Fallback
 --- | --- | ---
-`index` | Home page | 
+`index` | Home page |
 `post` | Posts | `index`
 `page` | Pages | `index`
 `archive` | Archives | `index`
@@ -13,7 +13,7 @@ Template | Page | Fallback
 
 ## Layouts
 
-If pages share simliar structure, for instance, two templates have header and footer. You can consider use "layout" to make two templates share the same structure. A layout file should be able to display the content of `body` variable so the content of templates can be displayed. For example:
+When pages share a similar structure - for instance, when two templates have both a header and a footer - you can consider using a `layout` to declare these structural similarities. Every layout file should contain a `body` variable to display the contents of the template in question. For example:
 
 ``` html index.ejs
 index
@@ -35,11 +35,11 @@ yields:
 </html>
 ```
 
-Every templates apply to `layout` template by default. You can specify other layouts in front-matter or `false` to disable it. You can even use other layouts in a layout to build a nested layout.
+By default, the `layout` template is used by all other templates. You can specify additional layouts in the front-matter or set it to `false` to disable it. It's even possible to build a complex nested structure by including more layout templates in your top layout.
 
 ## Partials
 
-Partials help you share components between templates, such as header, footer or sidebar. You can separate them into files and make maintenance more convenient. For example:
+Partials are useful for sharing components between your templates. Typical examples include headers, footers or sidebars. You may want to put your partials in separate files to make maintaining your website significantly more convenient. For example:
 
 
 ``` html partial/header.ejs
@@ -80,11 +80,11 @@ yields:
 
 ## Optimization
 
-If your theme is too complicated or there're too may files needed to be generate. Generation performance may decrease a lot. Besides simplifying your theme, you can also try Fragment Caching introduced in Hexo 2.7.
+If your theme is exceedingly complex or if the number of files to generate becomes too large, Hexo's file generation performance may begin to decrease considerably. Aside from simplifying your theme, you may also try Fragment Caching, which was introduced in Hexo 2.7.
 
-This feature is stolen from [Ruby on Rails](http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching). It saves the contents within a fragment and serves the cache when the next request comes in. It can reduce database queries and make generation faster.
+This feature was borrowed from [Ruby on Rails](http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching). It causes content to be saved as fragments and cached for when additional requests are made. This can reduce the number of database queries and can also speed up file generation.
 
-It can be used in header, footer, sidebar or static contents that won't be changed in your templates. For example:
+Fragment caching is best used for headers, footers, sidebars or other static content that is unlikely to change from template to template. For example:
 
 ``` js
 <%- fragment_cache('header', function(){
@@ -92,10 +92,10 @@ It can be used in header, footer, sidebar or static contents that won't be chang
 });
 ```
 
-It would be easier if you use partials:
+Though it may be easier to use partials:
 
 ``` js
 <%- partial('header', {}, {cache: true});
 ```
 
-However, don't use fragment caching with `relative_link` setting enabled. Because relative links may be different in each pages.
+Don't use fragment caching when the `relative_link` setting has been enabled. This may cause issues because relative links can and probably will be different depending on the pages they appear in.

--- a/source/docs/themes.md
+++ b/source/docs/themes.md
@@ -1,6 +1,6 @@
 title: Themes
 ---
-It's easy to build a Hexo theme - you just have to create a new folder. To start using your theme, modify the `theme` setting in your site's `_config.yml`. A theme may have the following structure:
+It's easy to build a Hexo theme - you just have to create a new folder. To start using your theme, modify the `theme` setting in your site's `_config.yml`. A theme should have the following structure:
 
 ``` plain
 .
@@ -13,7 +13,7 @@ It's easy to build a Hexo theme - you just have to create a new folder. To start
 
 ### _config.yml
 
-Theme configuration file. You don't need to restart the server after changing this.
+Theme configuration file. Modifying this doesn't require a server restart.
 
 ### languages
 
@@ -21,7 +21,7 @@ Language folder. See [localization (i18n)](localization.html) for more info.
 
 ### layout
 
-Layout folder. This folder contains the theme's template files, which define the appearance of your website. Hexo provides the [Swig] template engine. You can install plugins to support alternative engines such as [EJS], [Haml] or [Jade]. Hexo chooses the template engine based on the file extension of the template. For example:
+Layout folder. This folder contains the theme's template files, which define the appearance of your website. Hexo provides the [Swig] template engine by default, but you can easily install additional plugins to support alternative engines such as [EJS], [Haml] or [Jade]. Hexo chooses the template engine based on the file extension of the template. For example:
 
 ``` plain
 layout.ejs   - uses EJS
@@ -32,17 +32,17 @@ See [templates](templates.html) for more info.
 
 ### scripts
 
-Script folder. JavaScript files in this folder will be loaded when Hexo starts. For more info, see [plugins](plugins.html).
+Script folder. Hexo will automatically load all JavaScript files in this folder during initialization. For more info, see [plugins](plugins.html).
 
 ### source
 
-Source folder. Assets (e.g. CSS and JavaScript files) should be placed here. Hexo ignores hidden files and files or folders prefixed with `_` (underscore).
+Source folder. Place your assets (e.g. CSS and JavaScript files) here. Hexo ignores hidden files and files or folders prefixed with `_` (underscore).
 
-Files that can be rendered are processed and saved to the `public` folder. Other files are copied to the `public` folder directly.
+Hexo will process and save all renderable files to the `public` folder. Non-renderable files will be copied to the `public` folder directly.
 
 ### Publishing
 
-Once your theme is complete, you can publish it to the [theme list](/themes). Before publishing, you should run the [theme unit test](https://github.com/hexojs/hexo-theme-unit-test) and ensure everything works. The steps for publishing a theme are very simliar to those for [updating documentation](contributing.html#Updating_Documentation).
+When you have finished building your theme, you can publish it to the [theme list](/themes). Before doing so, you should run the [theme unit test](https://github.com/hexojs/hexo-theme-unit-test) to ensure that everything works. The steps for publishing a theme are very similar to those for [updating documentation](contributing.html#Updating_Documentation).
 
 1. Fork [hexojs/site]
 2. Clone the repository to your computer and install dependencies.

--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 title: Troubleshooting
 ---
-You may encounter some problems when using Hexo. The following are the solutions to the problems that people frequently asked. If you can't find the answer here, you can try to find the answer on [GitHub](https://github.com/hexojs/hexo/issues) or [Google Group](https://groups.google.com/group/hexo).
+In case you're experiencing problems with using Hexo, here is a list of solutions to some frequently encountered issues. If this page doesn't help you solve your problem, try doing a search on [GitHub](https://github.com/hexojs/hexo/issues) or our [Google Group](https://groups.google.com/group/hexo).
 
 ## YAML Parsing Error
 
@@ -16,7 +16,7 @@ JS-YAML: bad indentation of a mapping entry at line 18, column 31:
       last_updated:"Last updated: %s"
 ```
 
-Make sure you are using soft tab and add a space after colons.
+Make sure you are using soft tabs and add a space after colons.
 
 You can see [YAML Spec](http://www.yaml.org/spec/1.2/spec.html) for more info.
 
@@ -26,7 +26,7 @@ You can see [YAML Spec](http://www.yaml.org/spec/1.2/spec.html) for more info.
 Error: EMFILE, too many open files
 ```
 
-Though Node.js has non-blocking I/O, the number of synchronous I/O is still limited by system. You may come across EMFILE error when trying to generate a large number of files. You can try to run the following command to increase the number of synchronous I/O.
+Though Node.js has non-blocking I/O, the maximum number of synchronous I/O is still limited by the system. You may come across an EMFILE error when trying to generate a large number of files. You can try to run the following command to increase the number of allowed synchronous I/O operations.
 
 ``` bash
 $ ulimit -n 10000
@@ -46,7 +46,7 @@ Make sure you have [set up git](https://help.github.com/articles/set-up-git) on 
 Error: listen EADDRINUSE
 ```
 
-You may have started two Hexo server at the same time or there's another application using the same port. Try to edit `port` setting or start Hexo server with `-p` flag.
+You may have started two Hexo servers at the same time or there might be another application using the same port. Try to modify the `port` setting or start the Hexo server with the `-p` flag.
 
 ``` bash
 $ hexo server -p 5000
@@ -58,11 +58,11 @@ $ hexo server -p 5000
 npm ERR! node-waf configure build
 ```
 
-This error may occurred when you trying to install a plugin written in C, C++ or other non-JavaScript language. Make sure you have installed compiler on your computer.
+This error may occur when trying to install a plugin written in C, C++ or another non-JavaScript language. Make sure you have installed the right compiler on your computer.
 
 ## Iterate Data Model on Jade or Swig
 
-Hexo uses [Warehouse] as data model. It's not an array so you have to transform them into to iterate.
+Hexo uses [Warehouse] for its data model. It's not an array so you may have to transform objects into iterables.
 
 ```
 {% for post in site.posts.toArray() %}
@@ -71,7 +71,7 @@ Hexo uses [Warehouse] as data model. It's not an array so you have to transform 
 
 ## Data Not Updated
 
-Some data may not be updated, or generated files are same to the last version. You can clean the cache and try again.
+Some data cannot be updated, or the newly generated files are identical to those of the last version. Clean the cache and try again.
 
 ``` bash
 $ hexo clean
@@ -79,7 +79,7 @@ $ hexo clean
 
 ## Escape Contents
 
-Hexo uses [Nunjucks] to render posts (used [Swig] in old version, they shared a simliar syntax). Contents wrapped with `{% raw %}{{ }}{% endraw %}` or `{% raw %}{% %}{% endraw %}` will be parsed and may cause problems. You can wrap sensitive contents with `raw` tag plugin.
+Hexo uses [Nunjucks] to render posts ([Swig] was used in older version, which share a similar syntax). Content wrapped with `{% raw %}{{ }}{% endraw %}` or `{% raw %}{% %}{% endraw %}` will get parsed and may cause problems. You can wrap sensitive content with the `raw` tag plugin.
 
 ```
 {% raw %}

--- a/source/docs/writing.md
+++ b/source/docs/writing.md
@@ -28,7 +28,7 @@ By default, Hexo uses the post title as its filename. You can edit the `new_post
 
 Placeholder | Description
 --- | ---
-`:title` | Post title (lower case, with spaces replaced by a hyphen)
+`:title` | Post title (lower case, with spaces replaced by hyphens)
 `:year` | Created year, e.g. `2015`
 `:month` | Created month (leading zeros), e.g. `04`
 `:i_month` | Created month (no leading zeros), e.g. `4`
@@ -37,7 +37,7 @@ Placeholder | Description
 
 ### Drafts
 
-Previously, we mentioned a special layout in Hexo: `draft`. Posts with this layout are saved to `source/_drafts` folder. You can use the `publish` command to move drafts to `source/_posts` folder. This command works in a simliar way to the `new` command.
+Previously, we mentioned a special layout in Hexo: `draft`. Posts initialized with this layout are saved to the `source/_drafts` folder. You can use the `publish` command to move drafts to the `source/_posts` folder. `publish` works in a similar way to the `new` command.
 
 ``` bash
 $ hexo publish [layout] <title>


### PR DESCRIPTION
I read through the docs and edited them as I went along.

There was an issue with showing off the triple backtick code in the tag-plugins.md file, causing it to error out. I changed it so at least the syntax is shown now, but it's still not looking great since the engine processes any appearance of triple backticks (even in a code block or a raw tag).