### PR TITLE
add plugin: hexo-filter-fix-cjk-spacing

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -539,3 +539,11 @@
     - cli
     - editor
     - admin
+- name: hexo-filter-fix-cjk-spacing
+  description: Join continuous CJK lines in markdown before rendering.
+  link: https://github.com/lotabout/hexo-filter-fix-cjk-spacing
+  tags:
+    - filter
+    - cjk
+    - spacing
+    - line


### PR DESCRIPTION
Hi, I add a plug-in to fix the spacing problem of CJK lines in markdown parsing:

```
.....中文结尾
中文顶格...

will result in

.....中文结尾 中文顶格...
             `- note the space here
```

This plug-in will fix that.
