### PR TITLE
Clarify that helpers can't be used in source files

### DIFF
--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -1,6 +1,6 @@
 title: Helpers
 ---
-Helpers are used in templates to help you insert snippets quickly.
+Helpers are used in templates to help you insert snippets quickly.  Helpers cannot be used in source files.
 
 ## URL
 


### PR DESCRIPTION
Hi, I (and it seems [others](https://github.com/hexojs/hexo/issues/408)) have been confused by the fact that you can't use helper functions in source files.  I think it might be helpful to state this explicitly.  I'm also curious why this is the case.