### PR TITLE
add hexo-tag-githubimage plugin to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -567,3 +567,13 @@
     - bilibili
     - niconico
     - youtube
+- name: hexo-tag-githubimage
+  description: Inserts an image tag using a github content distribution.
+  link: https://github.com/wizicer/hexo-tag-githubimage/ 
+  tags:
+    - website
+    - blog
+    - hexo
+    - image
+    - embedded
+    - github


### PR DESCRIPTION
updated the hexo-tag-githubimage to support Hexo V3.x.