### PR TITLE
adding hexo-imgix plugin to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1,6 +1,6 @@
 - name: hexo-helper-obfuscate
   description: Obfuscate strings using html entities. Handy against crawlers.
-  link: https://github.com/andrewpeterprifer/hexo-helper-obfuscate/ 
+  link: https://github.com/andrewpeterprifer/hexo-helper-obfuscate/
   tags:
     - helper
     - obfuscate
@@ -580,7 +580,7 @@
     - youtube
 - name: hexo-tag-githubimage
   description: Inserts an image tag using a github content distribution.
-  link: https://github.com/wizicer/hexo-tag-githubimage/ 
+  link: https://github.com/wizicer/hexo-tag-githubimage/
   tags:
     - website
     - blog
@@ -588,3 +588,14 @@
     - image
     - embedded
     - github
+- name: hexo-imgix
+  description: "Use the imgix API for image manipulation via a tag, filter and helper."
+  link: https://github.com/mshick/hexo-imgix/
+  tags:
+    - hexo
+    - imgix
+    - filter
+    - tag
+    - helper
+    - manipulation
+    - image


### PR DESCRIPTION
I created this trio of tools to aid in offloading image processing tasks on the service-provider imgix, which has a great, full-featured API and is cheap. I think it makes a great compliment to a simple static site where more control over images is needed.

Briefly:

* the **tag** {% imgix %} is a slightly modified version of the native Hexo {% img %} tag, supporting imgix api params and doing domain replacement for applicable paths / urls.
* the **helper** does the heavy lifting for the above process, and is exposed in templates for use there
* the **filter** registers with the before_render hook to parse out markdown-defined images, apply imgix domains to them, and optionally will apply configured params and / or sizing data (specified through the proposed markdown extension).

