### PR TITLE
add plugin hexo-filter-indicate-the-source

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -47,6 +47,13 @@
     - tag
     - ruby-character
     - pinyin
+- name: hexo-filter-indicate-the-source
+  description: Insert informations that can indicate the source of blog posts.
+  link: https://github.com/JamesPan/hexo-filter-indicate-the-source
+  tags:
+    - filter
+    - indicate-the-source
+    - anti-crawl
 - name: hexo-server
   description: Server module for Hexo.
   link: https://github.com/hexojs/hexo-server


### PR DESCRIPTION
I wrote a plugin these days to add 'indicate the source' informations to posts without hurting readers' reading experience.

Visit my blog for more detail.

https://blog.jamespan.me/2016/01/15/do-not-forget-to-indicate-the-source/