### PR TITLE
Correct library used

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -37,7 +37,7 @@ Setting | Description | Default
 `category_dir` | Category directory | `categories`
 `code_dir` | Include code directory | `downloads/code`
 `i18n_dir` | i18n directory | `:lang`
-`skip_render` | Paths not to be rendered. You can use [glob expressions](https://github.com/isaacs/node-glob) for path matching |
+`skip_render` | Paths not to be rendered. You can use [glob expressions](https://github.com/isaacs/minimatch) for path matching |
 
 ### Writing
 


### PR DESCRIPTION
minimatch is used by glob, but there's no indication they'll have the same defaults etc. without examples, this is a confusing link.