### PR TITLE
Add hexo-tag-imgurgal information

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -505,6 +505,16 @@
     - flickr
     - photo
     - image
+- name: hexo-tag-imgurgal
+  description: Embed imgur galleries/albums
+  link: https://github.com/DrummerHead/hexo-tag-imgurgal
+  tags:
+    - tag
+    - imgur
+    - photos
+    - image
+    - gallery
+    - album
 - name: hexo-tag-vine
   description: Embed your Vine videos in posts/pages.
   link: https://github.com/welksonramos/hexo-tag-vine


### PR DESCRIPTION
Adds reference information for the hexo-tag-imgurgal tag plugin that can be found here: https://github.com/DrummerHead/hexo-tag-imgurgal

Cheers!