### PR TITLE
update docs, include your plugin in package.json

### DIFF
--- a/source/docs/plugins.md
+++ b/source/docs/plugins.md
@@ -28,6 +28,8 @@ At the very least, you should set the `name`, `version` and `main` entries in `p
 }
 ```
 
+You'll also need to list your plugin as a dependency in the root `package.json` of your hexo instance in order for Hexo to detect and load it.
+
 ### Tools
 
 You can make use of the official tools provided by Hexo to accelerate development:


### PR DESCRIPTION
Ran into this today, I from reading the docs I thought hexo would detect my plugin from the file system, adding this line to the docs clarifies things.