### PR TITLE
Add hexo-github-card plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -729,3 +729,11 @@
     - css
     - critical
     - filter
+- name: hexo-github-card
+  description: "Display a card for GitHub profile and repo in your hexo blog post."
+  link: https://github.com/Gisonrg/hexo-github-card
+  tags:
+    - tag
+    - github
+    - card
+    - profile


### PR DESCRIPTION
Hi,

I created a [plugin](https://github.com/Gisonrg/hexo-github-card) that can show GitHub user and repo information. Please help to add to the site :smile: 

Thank you!