### PR TITLE
Add hexo-autolinker plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -737,3 +737,12 @@
     - github
     - card
     - profile
+- name: hexo-autolinker
+  description: "Automatically create HTML links from URLs, emails, Twitter handles and more."
+  link: https://github.com/klugjo/hexo-autolinker
+  tags:
+    - hexo-autolinker
+    - hyperlink
+    - link
+    - email
+    - URL


### PR DESCRIPTION
I created a plugin that converts all URLs and emails to HTML links.

Various options available to also convert phone numbers, twitter handles and hashtags + possibility to add custom classes.

Thanks