### PR TITLE
add hexo-footnotes plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -448,3 +448,10 @@
     - flickr
     - photo
     - image
+- name: hexo-footnotes
+  description: A plugin to support markdown footnotes in your Hexo blog posts
+  link: https://github.com/LouisBarranqueiro/hexo-footnotes
+  tags:
+    - filter
+    - markdown
+    - footnotes


### PR DESCRIPTION
A plugin to support markdown footnotes in your Hexo blog posts