### PR TITLE
added hexo-url-image plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -736,6 +736,13 @@
     - image
     - json
     - json-content
+- name: hexo-url-image
+  description: "adding url_image in front-matter, then refer post.url_image in your templates;"
+  link: https://github.com/roybein/hexo-url-image
+  tags:
+    - hexo-url-image
+    - url
+    - image
 - name: hexo-tag-admonition
   description: "Tag plugin for inserting admonition in your blog."
   link: https://github.com/haishanh/hexo-tag-admonition


### PR DESCRIPTION
let template can refer the image url set in post markdown, it's useful in case like, you want to set a cover image for each blog post, and serve the image by image cloud server.