### PR TITLE
Link Dead

### DIFF
--- a/source/docs/contributing.md
+++ b/source/docs/contributing.md
@@ -8,7 +8,7 @@ We welcome you to join the development of Hexo. This document will help you thro
 
 Please follow the coding style:
 
-- Follow [Google JavaScript Style Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+- Follow [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml).
 - Use soft-tabs with a two space indent.
 - Don't put commas first.
 


### PR DESCRIPTION
Link to Google "JavaScript Style Guide " is dead .  It is now on Github not on SVN.