### PR TITLE
Fix the wrong name of hexo-generator-i18n

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -873,7 +873,7 @@
     - github
     - generator
     - helper
-- name: hexo-generator-118n
+- name: hexo-generator-i18n
   description: "Multi-languages pages generator for Hexo"
   link: https://github.com/Jamling/hexo-generator-i18n
   tags:


### PR DESCRIPTION
Fix the i18n typed wrong to 118n issue