### PR TITLE
Fix typo in docs/variables.md

### DIFF
--- a/source/docs/variables.md
+++ b/source/docs/variables.md
@@ -59,7 +59,7 @@ Variable | Description
 Variable | Description
 --- | ---
 `page.per_page` | Posts displayed per page
-`page.total` | Total number of posts
+`page.total` | Total number of pages
 `page.current` | Current page number
 `page.current_url` | The URL of current page
 `page.posts` | Posts in this page ([Data Model])


### PR DESCRIPTION
`page.total` in **HOME(index)** means total number of **pages** not posts