### PR TITLE
api: generator: Update data for archive generator

### DIFF
--- a/source/api/generator.md
+++ b/source/api/generator.md
@@ -50,7 +50,7 @@ Next, set the `layout` attribute to render with the theme templates. We're setti
 hexo.extend.generator.register('archive', function(locals){
   return {
     path: 'archives/index.html',
-    data: locals.posts,
+    data: locals,
     layout: ['archive', 'index']
   }
 });


### PR DESCRIPTION
The archive page example should have `data: locals` instead of `data: locals.posts` or an error will occur.

Test on: hexo: 3.2.2

Test script and versions documented @ https://gist.github.com/7ef9b57152f241d2421c5d1b9355a1da