### PR TITLE
Adding hexo-tag-html5video to plugin list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1,3 +1,12 @@
+- name: hexo-tag-html5video
+  description: Embed html5 video player and play videos stored in asset_path or elsewhere in public folder for Hexo.
+  link: https://github.com/stephenmkbrady/hexo-tag-html5
+  tags:
+    - tag_plugins
+    - mp4
+    - html5video
+    - webm    
+    - video
 - name: hexo-generator-fragments
   description: Generate paged html fragments for `Index`, `Category` and `Tag` pages, let `Hexo` support elegant ajax pagination.
   link: https://github.com/mamboer/hexo-generator-fragments


### PR DESCRIPTION
Added to the plugin list.
Plugin lets you embed upload videos in your asset_path or elsewhere on the server.

Install:
npm i hexo-tag-html5video

Usage: 
With no args, the defaults are used: width = '100%' height = '250px' codec = 'video/webm'
{% html5video %} {% asset_path big-buck-bunny_trailer.webm %} {% endhtml5video %}

or with args:
{% html5video '100%' '250px' 'video/mp4' %} {% asset_path big-buck-bunny_trailer.webm %} {% endhtml5video %}