### PR TITLE
hexo-sync-plugin for retrieving posts and drafts from Google Drive

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1249,3 +1249,9 @@
   tags:
     - deployer
     - UPYUN
+- name: hexo-sync-gdrive
+  description: Retrieve posts and drafts from Google Drive
+  link: https://github.com/hollanddd/hexo-sync-gdrive
+  tags:
+    - google
+    - console


### PR DESCRIPTION
A workflow plugin that leverages the Google Drive API for pulling `text/markdown` files from Google Drive. To and from folders are configurable. Any feedback you can provide would be greatly appreciated