### PR TITLE
Hexo官网 Theme下标签被转成了单个字符 已修复

### DIFF
--- a/source/_data/themes.yml
+++ b/source/_data/themes.yml
@@ -12,7 +12,8 @@
   description: Ada is an concise theme for Hexo.
   link: https://github.com/shuiRong/hexo-theme-Ada
   preview: https://shuirong.github.io/
-  tags: concise
+  tags: 
+      - concise
       - one_column
       - white
       - clean


### PR DESCRIPTION
现在是这样的：  #c #l #e #a #n   
应该是这样的： #clean