### PR TITLE
Add deploy to Netlify Context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Hexo Official Website
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/hexojs/site)
 
 [![Build Status](https://travis-ci.org/hexojs/site.svg?branch=master)](https://travis-ci.org/hexojs/site)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "hexo generate"
+  publish = "/public"


### PR DESCRIPTION
# What is this?
I added a deploy to Netlify button to the README. Feel free to test it out below. The toml file just tells Netlify that your index.html is in the root and your build command is `hexo generate`. I did this, because I want to add a hexo example to http://www.staticgen.com/ and this would help.

Netlify also has a liberal [Open Source](https://netlify.com/open-source) plan for all open source projects, in case you had some other hexo examples you would like to host there. 

<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/site)

Let me know if you have questions. 