### PR TITLE
Add hexo-image-sizes plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1421,3 +1421,9 @@
   tags:
     - renderer
     - sass
+- name: hexo-image-sizes
+  description: Generate multiple images sizes (thumbnail, body, etc.) for each source image
+  link: https://github.com/ottobonn/hexo-image-sizes
+  tags:
+    - images
+    - processor


### PR DESCRIPTION
This plugin lets you generate multiple sizes of each image in your `source` directory; for example, thumbnails and gallery images.