### PR TITLE
Add hexo-instagram-wall to plugin registry

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1427,3 +1427,10 @@
   tags:
     - images
     - processor
+- name: hexo-instagram-wall
+  description: Displays up to 18 most recent images from your Instagram account
+  link: https://github.com/rdgpt/hexo-instagram-wall
+  tags:
+    - filter
+    - helper
+    - instagram


### PR DESCRIPTION
This pull request is simply to add a plugin to the Hexo website. 

The plugin is a template helper, which can add images from an Instagram account to the website.