### PR TITLE
Add plugin hexo-helper-htmlentities

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1455,3 +1455,11 @@
     - generator
     - index
     - top|置顶
+- name: hexo-helper-htmlentities
+  description: Hexo helper plugin for encoding html entities.
+  link: https://github.com/kulikala/hexo-helper-htmlentities
+  tags:
+    - helper
+    - html-entities
+    - encode
+    - entities


### PR DESCRIPTION
Added `hexo-helper-htmlentities` plugin to encode html entities using [node-html-entities](https://github.com/mdevils/node-html-entities).