### PR TITLE
Fix horisontal scrolling

### DIFF
--- a/themes/navy/source/css/_partial/base.styl
+++ b/themes/navy/source/css/_partial/base.styl
@@ -33,7 +33,6 @@ body
   text-rendering: optimizeLegibility
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
-  position: relative
 
 .wrapper
   clearfix()

--- a/themes/navy/source/css/_partial/base.styl
+++ b/themes/navy/source/css/_partial/base.styl
@@ -33,6 +33,7 @@ body
   text-rendering: optimizeLegibility
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
+  overflow-x: hidden
 
 .wrapper
   clearfix()


### PR DESCRIPTION
Fixes #448 

`position: relative` on body is redundant, as without positioned ancestor the absolute element is positioned relative to html anyway.

P.S.
I also tried bringing the `mobile-nav-toggle` in front of the dimmer, as it looks like it was intended to be on top. But it is not possible with css alone, as its parent `#container` has a [transform](https://www.w3.org/TR/css-transforms-1/#module-interactions) on it, which creates a [stacking context](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/). Meaning the container and hamburger button are grouped together and can only be either both on top of the dimmer or both below.

I know it isn't a breaking bug. But still it would be nice to fix it.