### PR TITLE
Add plugin hexo-directory-category

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1463,3 +1463,11 @@
     - html-entities
     - encode
     - entities
+- name: hexo-directory-category
+  description: Automatically add category to Hexo article according to the article file directory.
+  link: https://github.com/zthxxx/hexo-directory-category
+  tags:
+    - category
+    - auto
+    - directory
+    - processor


### PR DESCRIPTION
Add plugin hexo-directory-category

Automatically add category to Hexo article according to the article file directory.