### PR TITLE
Fix horisontal scroll

### DIFF
--- a/themes/navy/source/css/_partial/mobile_nav.styl
+++ b/themes/navy/source/css/_partial/mobile_nav.styl
@@ -125,12 +125,12 @@ lang-select-height = 40px
   position: absolute
   top: 0
   left: 100%
-  width: 100%
   height: 100%
   background: #000
   opacity: 0
   transition: opacity transition-duration, transform 0s transition-duration
   .mobile-nav-on &
+    width: 100%
     opacity: 0.7
     transform: translateX(-100%)
     transition: opacity transition-duration


### PR DESCRIPTION
Don't know why `overflow-x: hidden` in #449 doesn't work on iOS Safari, so problem #448 still not solved. I tried to move `width: 100%` from `#mobile-nav-dimmer` to `.mobile-nav-on:#mobile-nav-dimmer`, worked fine on me.
Can anyone have a check on this? I don't have much experience on css, hope not to cause another problem, thanks ;)