### PR TITLE
Add hexo-generator-json-feed-org to plugins list

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1504,3 +1504,13 @@
     - markdown
     - ppt
     - reveal
+- name: hexo-generator-json-feed-org
+  description: Generate a JSON feed as per the jsonfeed.org specification
+  link: https://github.com/rmlewisuk/hexo-generator-json-feed-org
+  tags:
+    - generator
+    - content
+    - json
+    - feed
+    - rss
+    - jsonfeed


### PR DESCRIPTION
Adds [hexo-generator-json-feed-org](https://github.com/rmlewisuk/hexo-generator-json-feed-org), a plugin to generate a valid [jsonfeed.org](http://jsonfeed.org) feed.

Note: this is distinctly different from https://github.com/alexbruno/hexo-generator-json-feed as that is more of a general purpose JSON/API endpoint.

Was discussed in https://github.com/hexojs/hexo-generator-feed/issues/55, linking here for the sake of completeness.