### PR TITLE
Update Google JavaScript Style Guide Url

### DIFF
--- a/source/docs/contributing.md
+++ b/source/docs/contributing.md
@@ -8,7 +8,7 @@ We welcome you to join the development of Hexo. This document will help you thro
 
 Please follow the coding style:
 
-- Follow [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml).
+- Follow [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html).
 - Use soft-tabs with a two space indent.
 - Don't put commas first.
 

--- a/source/ko/docs/contributing.md
+++ b/source/ko/docs/contributing.md
@@ -8,7 +8,7 @@ title: Contributing
 
 아래의 코딩 스타일을 지켜주세요.
 
-- [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml)를 따릅니다.
+- [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)를 따릅니다.
 - 두 개의 공백을 사용한 soft-tab을 사용합니다.
 - 콤마로 시작하지 마세요.
 

--- a/source/ru/docs/contributing.md
+++ b/source/ru/docs/contributing.md
@@ -8,7 +8,7 @@ title: Содействие
 
 Пожалуйста, следите за стилем написания кода:
 
-- Следуйте [Google JavaScript Style Guide](https://google.github.io/styleguide/javascriptguide.xml).
+- Следуйте [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html).
 - Используйте мягкие табы с двойным пробелом.
 - Не ставьте запятую в начале.
 

--- a/source/zh-tw/docs/contributing.md
+++ b/source/zh-tw/docs/contributing.md
@@ -8,7 +8,7 @@ title: 貢獻
 
 請遵守以下準則：
 
-- 遵守 [Google JavaScript 代碼風格](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)。
+- 遵守 [Google JavaScript 代碼風格](https://google.github.io/styleguide/jsguide.html)。
 - 使用 2 個空格縮排。
 - 不要把逗號放在最前面。
 
@@ -81,7 +81,7 @@ Hexo 文件開放原始碼，您可以在 [hexojs/site] 找到原始碼。
 
 ## 回報問題
 
-當您在使用 Hexo 時遭遇問題，您可試著在 [解決問題](troubleshooting.html) 中尋找解答，或是在 [GitHub](https://github.com/hexojs/hexo/issues) 或 [Google Group](https://groups.google.com/group/hexo) 詢問。詢問時請務必附上以下資訊：
+當您使用 Hexo 遭遇問題時，可試著在 [解決問題](troubleshooting.html) 中尋找解答，或是在 [GitHub](https://github.com/hexojs/hexo/issues) 或 [Google Group](https://groups.google.com/group/hexo) 詢問。若找不到答案，請至 GitHub 回報。
 
 1. 以 [除錯模式](commands.html#除錯模式) 再執行一次。
 2. 執行 `hexo vesion` 並檢查版本資訊。


### PR DESCRIPTION
The original guide page (https://google.github.io/styleguide/javascriptguide.xml) shows:

"Please note: there's a newer version of this guide that includes ECMAScript 6th Edition features. It lives here (https://google.github.io/styleguide/jsguide.html)."