### PR TITLE
Fix internal link & let zh-tw docs match en docs in the range of "Getting Started"

### DIFF
--- a/source/zh-tw/api/filter.md
+++ b/source/zh-tw/api/filter.md
@@ -63,7 +63,7 @@ hexo.extend.filter.unregister(type, filter);
 
 ### before_post_render
 
-在文章開始渲染前執行。您可參考 [文章渲染](api/posts.html#渲染) 以瞭解執行順序。
+在文章開始渲染前執行。您可參考 [文章渲染](posts.html#渲染) 以瞭解執行順序。
 
 舉例來說，把標題轉為小寫：
 
@@ -76,7 +76,7 @@ hexo.extend.filter.register('before_post_render', function(data){
 
 ### after_post_render
 
-在文章渲染完成後執行。您可參考 [文章渲染](api/posts.html#渲染) 以瞭解執行順序。
+在文章渲染完成後執行。您可參考 [文章渲染](posts.html#渲染) 以瞭解執行順序。
 
 舉例來說，把 `@username` 取代為 Twitter 的使用者連結。
 
@@ -162,7 +162,7 @@ hexo.extend.filter.register('post_permalink', function(data){
 
 ### after_render
 
-在渲染後執行，您可參考 [渲染](api/rendering.html#after_render_過濾器) 以瞭解更多資訊。
+在渲染後執行，您可參考 [渲染](rendering.html#after_render_過濾器) 以瞭解更多資訊。
 
 ### server_middleware
 

--- a/source/zh-tw/docs/commands.md
+++ b/source/zh-tw/docs/commands.md
@@ -43,7 +43,7 @@ $ hexo publish [layout] <filename>
 $ hexo server
 ```
 
-啟動伺服器。
+啟動伺服器，預設是 `http://localhost:4000/`。
 
 選項 | 描述
 --- | ---
@@ -66,7 +66,7 @@ $ hexo deploy
 ## render
 
 ``` bash
-$ hexo render <file> ...
+$ hexo render <file> [file2] ...
 ```
 
 渲染檔案。
@@ -133,13 +133,17 @@ $ hexo --silent
 
 隱藏終端機的訊息。
 
-### 自定配置檔的路徑
+### 自訂配置檔的路徑
 
 ``` bash
 $ hexo --config custom.yml
 ```
 
-自訂配置檔的路徑而不是使用 `_config.yml`。
+自訂配置檔的路徑而不是使用 `_config.yml`。此參數也接受以逗號分隔的 JSON 或 YAML 檔列表字串 (不得含有空格)，它們將會被合併產生一個 `_multiconfig.yml`。
+
+``` bash
+$ hexo --config custom.yml,custom2.json
+```
 
 ### 顯示草稿
 
@@ -155,4 +159,4 @@ $ hexo --draft
 $ hexo --cwd /path/to/cwd
 ```
 
-自定目前工作目錄（Current working directory）的路徑。
+自訂目前工作目錄（Current working directory）的路徑。

--- a/source/zh-tw/docs/configuration.md
+++ b/source/zh-tw/docs/configuration.md
@@ -1,6 +1,6 @@
 title: 配置
 ---
-您可以在 `_config.yml` 中修改大部份的配置。
+您可以在 `_config.yml` 或 [替代配置檔](#Using-an-Alternate-Config) 中修改網站配置。
 
 ### 網站
 
@@ -10,8 +10,8 @@ title: 配置
 `subtitle` | 網站副標題
 `description` | 網站描述
 `author` | 您的名字
-`language` | 網站使用的語言
-`timezone` | 網站時區。Hexo 預設使用您電腦的時區。[時區列表](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+`language` | 網站使用的語言，參考 [2-lettter ISO-639-1 code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)，預設為 `en`
+`timezone` | 網站時區，Hexo 預設使用您電腦的時區，您可以在 [時區列表](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) 尋找適當的時區，例如 `America/New_York` 、 `Japan` 與 `UTC`
 
 ### 網址
 
@@ -19,47 +19,47 @@ title: 配置
 --- | --- | ---
 `url` | 網站的網址 |
 `root` | 網站的根目錄 |
-`permalink` | 文章 [永久連結](permalinks.html) 的格式 | :year/:month/:day/:title/
-`permalink_defaults` | 永久連結中各區段的預設值 |
+`permalink` | 文章 [永久連結](permalinks.html) 的格式 | `:year/:month/:day/:title/`
+`permalink_defaults` | `permalink` 中各區段的預設值 |
 
 {% note info 網站存放在子目錄 %}
-如果您的網站存放在子目錄中，例如 `http://yoursite.com/blog`，則請將您的 `url` 設為 `http://yoursite.com/blog` 並把 `root` 設為 `/blog/`。
+如果您的網站存放在子目錄中，例如 `http://example.org/blog`，請將您的 `url` 設為 `http://example.org/blog` 並把 `root` 設為 `/blog/`。
 {% endnote %}
 
 ### 目錄
 
 設定 | 描述 | 預設值
 --- | --- | ---
-`source_dir` | 原始檔案資料夾，這個資料夾用於存放您的內容。 | source
-`public_dir` | 靜態檔案資料夾，這個資料夾用於存放建立完畢的檔案。 | public
-`tag_dir` | 標籤資料夾 | tags
-`archive_dir` | 彙整資料夾 | archives
-`category_dir` | 分類資料夾 | categories
-`code_dir` | Include code 資料夾 | downloads/code
-`i18n_dir` | 國際化（i18n）資料夾 | :lang
-`skip_render` | 跳過指定檔案的渲染，您可使用 glob 來配對路徑。 |
+`source_dir` | 原始檔案資料夾，這個資料夾用於存放您的內容 | `source`
+`public_dir` | 靜態檔案資料夾，這個資料夾用於存放建立完畢的檔案 | public
+`tag_dir` | 標籤資料夾 | `tags`
+`archive_dir` | 彙整資料夾 | `archives`
+`category_dir` | 分類資料夾 | `categories`
+`code_dir` | Include code 資料夾 | `downloads/code`
+`i18n_dir` | 國際化（i18n）資料夾 | `:lang`
+`skip_render` | 跳過指定檔案的渲染，您可使用 [glob 表達式](https://github.com/isaacs/minimatch) 來配對路徑 |
 
 ### 寫作
 
 設定 | 描述 | 預設值
 --- | --- | ---
-`new_post_name` | 新文章的檔案名稱 | :title.md
-`default_layout` | 預設佈局 | post
-`auto_spacing` | 在西方文字與東方文字中加入空白 | false
-`titlecase` | 把標題轉換為 title case | false
-`external_link` | 在新頁籤中開啟連結 | true
-`filename_case` | 把檔案名稱轉換為 (1) 小寫或 (2) 大寫 | 0
-`render_drafts` | 顯示草稿 | false
-`post_asset_folder` | 啟動 [Asset 資料夾](asset-folders.html) | false
-`relative_link` | 把連結改為與根目錄的相對位址 | false
-`future` | 顯示未來的文章 | true
+`new_post_name` | 新文章的檔案名稱 | `:title.md`
+`default_layout` | 預設佈局 | `post`
+`auto_spacing` | 在西方文字與東方文字中加入空白 | `false`
+`titlecase` | 把標題轉換為 title case | `false`
+`external_link` | 在新頁籤中開啟連結 | `true`
+`filename_case` | 把檔案名稱轉換為: `1` 小寫或 `2` 大寫 | `0`
+`render_drafts` | 顯示草稿 | `false`
+`post_asset_folder` | 啟動 [Asset 資料夾](asset-folders.html) | `false`
+`relative_link` | 把連結改為與根目錄的相對位址 | `false`
+`future` | 顯示未來的文章 | `true`
 `highlight` | 程式碼區塊的設定 |
 
 ### 分類 & 標籤
 
 設定 | 描述 | 預設值
 --- | --- | ---
-`default_category` | 預設分類 | uncategorized
+`default_category` | 預設分類 | `uncategorized`
 `category_map` | 分類別名 |
 `tag_map` | 標籤別名 |
 
@@ -69,19 +69,56 @@ Hexo 使用 [Moment.js](http://momentjs.com/) 來解析和顯示時間。
 
 設定 | 描述 | 預設值
 --- | --- | ---
-`date_format` | 日期格式 | YYYY-MM-DD
-`time_format` | 時間格式 | H:mm:ss
+`date_format` | 日期格式 | `YYYY-MM-DD`
+`time_format` | 時間格式 | `HH:mm:ss`
 
 ### 分頁
 
 設定 | 描述 | 預設值
 --- | --- | ---
-`per_page` | 一頁顯示的文章量 (0 = 關閉分頁功能) | 10
-`pagination_dir` | 分頁目錄 | page
+`per_page` | 一頁顯示的文章量 (`0` = 關閉分頁功能) | `10`
+`pagination_dir` | 分頁目錄 | `page`
 
 ### 擴充套件
 
 設定 | 描述
 --- | ---
-`theme` | 目前主題
+`theme` | 使用主題名稱, 設為 `false` 表示關閉主題功能
 `deploy` | 佈署設定
+
+
+### 包含/排除 檔案或資料夾
+
+Hexo 會根據配置檔中 `include` / `exlude` 欄位設定，了解要 處理/忽略 哪些特定的檔案或資料夾。
+
+設定 | 描述
+--- | ---
+`include` | Hexo 預設會忽略隱藏檔與隱藏資料夾，但列在這個欄位中的檔案，Hexo 仍然會去處理
+`exclude` | 列在這裡的檔案將會被 Hexo 忽略
+
+範例:
+```yaml
+# 包含/排除 檔案或資料夾
+include:
+  - .nojekyll
+exclude:
+  - .DS_Store
+```
+
+### 使用替代配置檔
+
+使用 `hexo` 指令時，只要在指令後面加上 `--config` 參數與自訂配置檔 (需為 JSON 或 YAML 檔) 路徑即可指定此次想要搭配使用的配置檔。該參數也可以是以逗號分隔的檔案列表 (注意中間不得有空格) 來滿足一次使用多個配置檔的需求。
+
+範例:
+
+``` bash
+# 使用自訂的 'custom.yml' 取代預設的 '_config.yml'
+$ hexo server --config custom.yml
+
+# 使用多個配置檔, 有衝突時優先使用 'custom2.json'
+$ hexo server --config custom.yml,custom2.json
+```
+
+使用多個配置檔會合併產生一個 `_multiconfig.yml`。當合併遇到衝突時，列在愈後面的檔案，有愈高的優先權。可以使用任意數量帶有任意層級物件的 JSON 或 YAML 檔。注意**檔案列表字串中不得有空白**。
+
+以前述的多個配置檔範例來說明，若 `custom.yml` 中有 `foo: bar`，且 `custom2.json` 中有 `"foo": "dinosaur"`，最終在 `_multiconfig.yml` 裡的將會是 `foo: dinosaur`。

--- a/source/zh-tw/docs/index.md
+++ b/source/zh-tw/docs/index.md
@@ -1,6 +1,6 @@
 title: 文件
 ---
-歡迎使用 Hexo，此文件將幫助您快速開始使用。如果您在使用途中遇到任何問題，您可以在 [解決問題](docs/troubleshooting.html) 中找到解答，或者也可以在 [GitHub](https://github.com/hexojs/hexo/issues) 或 [Google Group](https://groups.google.com/group/hexo) 上詢問。
+歡迎使用 Hexo，此文件將幫助您快速開始使用。如果您在使用途中遇到任何問題，您可以在 [解決問題](troubleshooting.html) 中找到解答，或者也可以在 [GitHub](https://github.com/hexojs/hexo/issues) 或 [Google Group](https://groups.google.com/group/hexo) 上詢問。
 
 ## 什麼是 Hexo？
 
@@ -38,18 +38,18 @@ $ npm install -g hexo-cli
 
 ### 安裝 Node.js
 
-安裝 Node.js 的最佳方式是透過 [nvm](https://github.com/creationix/nvm)。
+安裝 Node.js 的最佳方式是透過 [Node Version Manager](https://github.com/creationix/nvm)。感謝 nvm 的開發者提供簡易自動安裝的腳本指令：
 
 cURL:
 
 ``` bash
-$ curl https://raw.github.com/creationix/nvm/master/install.sh | sh
+$ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 ```
 
 Wget:
 
 ``` bash
-$ wget -qO- https://raw.github.com/creationix/nvm/master/install.sh | sh
+$ wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 ```
 
 一旦安裝完成，重啟終端機並執行下列指令以安裝 Node.js。
@@ -62,7 +62,7 @@ $ nvm install stable
 
 ### 安裝 Hexo
 
-一旦所有的必備軟體都安裝完畢後，即可透過 npm 安裝 Hexo。
+一旦所有的必備軟體都安裝完畢後，即可透過 npm 安裝 Hexo：
 
 ``` bash
 $ npm install -g hexo-cli

--- a/source/zh-tw/docs/migration.md
+++ b/source/zh-tw/docs/migration.md
@@ -38,8 +38,30 @@ new_post_name: :year-:month-:day-:title.md
 $ npm install hexo-migrator-wordpress --save
 ```
 
-一旦外掛安裝完成，執行下列指令來轉移所有文章。`source` 可以是檔案路徑或網址。
+由 WordPress 儀表板的 "工具" → "匯出" → "WordPress" 匯出網站資料 (詳情請參見 [WordPress 支援頁](http://en.support.wordpress.com/export/))。
+
+接著執行：
 
 ``` bash
 $ hexo migrate wordpress <source>
 ```
+
+`source` 為 WordPress 匯出檔案的路徑或網址：
+
+## Joomla
+
+首先，安裝 `hexo-migrator-joomla` 外掛
+
+```bash
+$ npm install hexo-migrator-joomla --save
+```
+
+並使用 [J2XML](http://extensions.joomla.org/extensions/migration-a-conversion/data-import-a-export/12816?qh=YToxOntpOjA7czo1OiJqMnhtbCI7fQ%3D%3D) 元件匯出你的 Joomla 文章。
+
+接著執行：
+
+```bash
+$ hexo migrate joomla <source>
+```
+
+`source` 為 Joomla 匯出檔案的路徑或網址。

--- a/source/zh-tw/docs/setup.md
+++ b/source/zh-tw/docs/setup.md
@@ -15,7 +15,6 @@ $ npm install
 ├── _config.yml
 ├── package.json
 ├── scaffolds
-├── scripts
 ├── source
 |   ├── _drafts
 |   └── _posts
@@ -55,10 +54,6 @@ $ npm install
 ### scaffolds
 
 [鷹架](writing.html#鷹架（Scaffold）) 資料夾。當您建立新文章時，Hexo 會根據 scaffold 來建立檔案。
-
-### scripts
-
-[腳本](plugins.html#腳本（Scripts）) 資料夾。腳本是擴充 Hexo 的最簡易方式，在此資料夾內的 JavaScript 檔案會被自動執行。
 
 ### source
 


### PR DESCRIPTION
Fix internal link that still having wrong prefix "docs/" in zh-tw docs.

Let zh-tw docs match en docs in the range of "Getting Started".