### PR TITLE
adding hexo-number-title plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1557,3 +1557,10 @@
     - excerpt
     - abstract
     - description
+- name: hexo-number-title
+  description: the hexo blog post url is displayed as a number.
+  link: https://github.com/hluglk/hexo-number-title
+  tags:
+    - permalink
+    - link
+    - 固定链接


### PR DESCRIPTION
the hexo blog post url is displayed as a number