### PR TITLE
adding rtl and ltr tag plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1129,6 +1129,26 @@
   tags:
     - tag
     - keycaps
+- name: hexo-tag-ltr
+  description: Force LTR layout direction when used in a mixed RTL and LTR texts.
+  link: https://github.com/bluemix/hexo-tag-ltr
+  tags:
+    - tag
+    - ltr
+    - direction
+    - bidi
+    - multilingual
+    - left-to-right
+- name: hexo-tag-rtl
+  description: Force RTL layout direction when used in a mixed RTL and LTR texts.
+  link: https://github.com/bluemix/hexo-tag-rtl
+  tags:
+    - tag
+    - rtl
+    - direction
+    - bidi
+    - multilingual
+    - right-to-left
 - name: hexo-generator-index-i18n
   description: I18n index generator plugin for Hexo.
   link: https://github.com/xcatliu/hexo-generator-index-i18n


### PR DESCRIPTION

### RTL tag in an LTR document
```
{% rtl %}
مقتطفات من بعض الحكم
{% endrtl %}

“A small leak will sink a great ship.” - Benjamin Franklin

{% rtl %}
"لو أنك عشتَ في الماضي و تصرفت كأنك في الماضي ، سوف يكون صعباً على المُستقبلِ أن يراكَ." - Body of Lies
{% endrtl %}
```
which results in
<img width="563" alt="screenshot" src="https://user-images.githubusercontent.com/3332274/28766527-a3a6c1e4-75d8-11e7-8785-d5324b8491f5.png">

### LTR tag  in an RTL document
```
مقتطفات من بعض الحكم

{% ltr %}
“A small leak will sink a great ship.” - Benjamin Franklin
{% endltr %}

"لو أنك عشتَ في الماضي و تصرفت كأنك في الماضي ، سوف يكون صعباً على المُستقبلِ أن يراكَ." - Body of Lies
```
that results in
<img width="563" alt="screenshot" src="https://user-images.githubusercontent.com/3332274/28766609-09b2edbe-75d9-11e7-844f-77dce76a3736.png">

