### PR TITLE
theme renamed to match its lowercased screenshot

### DIFF
--- a/source/_data/themes.yml
+++ b/source/_data/themes.yml
@@ -17,7 +17,7 @@
     - clean
     - vuejs
     - elegant
-- name: Rexo
+- name: rexo
   description: Rexo is a minimally customized theme that supports RTL.
   link: https://github.com/bluemix/hexo-theme-rexo
   preview: https://bluemix.github.io


### PR DESCRIPTION
sorry for this, but the theme screenshot was not showing on Hexo Thems page.
the screenshot name must be _exactly_ like theme name in the yml.