### PR TITLE
add new plugin hexo-generator-issues

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1626,3 +1626,9 @@
     - tag
     - image
     - cloudinary
+- name: hexo-generator-issues
+  description: The Hexo plugin publish your posts to GitHub issues..
+  link: https://github.com/tcatche/hexo-generator-issues
+  tags:
+    - github
+    - issue


### PR DESCRIPTION
The Hexo plugin publish your posts to GitHub issues.