### PR TITLE
add plugin, Hexo-light-gallery

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1651,3 +1651,10 @@
   tags:
     - renderer
     - mustache
+- name: hexo-light-gallery
+  description: Generate gallery using light gallery for Hexo 图片预览 照片墙
+  link: https://github.com/lzane/hexo-light-gallery
+  tags:
+    - gallery
+    - photo
+    - lightgallery


### PR DESCRIPTION
Add a new plugin called Hexo-light-gallery.

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benifits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if interested this opputunity.
-->
