### PR TITLE
add the hexo-deployer-cos plugins

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1,3 +1,10 @@
+- name: hexo-deployer-cos
+  description: Tencent Cloud Object Storage (COS) plugin of Hexo.
+  link: https://github.com/sdlzhd/hexo-deployer-cos
+  tags:
+    - official
+    - deployer
+    - cos
 - name: hexo-tag-cplayer
   description: A hexo plugin for cPlayer.
   link: https://github.com/EYHN/hexo-tag-cplayer


### PR DESCRIPTION
<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benifits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if interested this opputunity.
-->
Add the hexo-deployer-cos plugin, COS is a  Object Storage platform from Tencent. You can used the plugin to deploy your Hexo blog to COS.