### PR TITLE
Add info about <!-- more --> to the docs

### DIFF
--- a/source/docs/tag-plugins.md
+++ b/source/docs/tag-plugins.md
@@ -242,3 +242,16 @@ If certain content is causing processing issues in your posts, wrap it with the 
 content
 {% endraw %}
 ```
+
+
+## Post Excerpt
+
+Use text placed before the `<!-- more -->` tag as an excerpt for the post.
+
+**Examples:**
+
+``` 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+<!-- more -->
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+```


### PR DESCRIPTION
I've added information about the `<!-- more -->` in the tag plugins section of the site. Technically, it's not a tag plugin, however this place looked the most suitable for me.

Fixes hexojs/hexo#2652.

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benifits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if interested this opputunity.
-->
