### PR TITLE
add hexo-pwa plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1724,7 +1724,7 @@
     - read-more
 - name: hexo-pwa
   description: A plugin make your site as a PWA, can be added to home screen and can work offline
-  link: https://github.com/lavas/hexo-pwa
+  link: https://github.com/lavas-project/hexo-pwa
   tags:
     - PWA
     - Service Worker

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1722,3 +1722,10 @@
     - excerpt
     - auto-excerpt
     - read-more
+- name: hexo-pwa
+  description: A plugin make your site as a PWA, can be added to home screen and can work offline
+  link: https://github.com/lavas/hexo-pwa
+  tags:
+    - PWA
+    - Service Worker
+    - Web App Manifest


### PR DESCRIPTION
Add `hexo-pwa` plugin.

`hexo-pwa` let Hexo sites have these two capabilities:
- Web App Manifest - Users can add your site to mobile home screen
- Service Worker - Make your site available offline

[https://github.com/lavas-project/hexo-pwa](https://github.com/lavas-project/hexo-pwa)
<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benifits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if interested this opputunity.
-->
