### PR TITLE
Fix pagination example. It would have made a route for

### DIFF
--- a/source/api/generator.md
+++ b/source/api/generator.md
@@ -64,7 +64,8 @@ You can use the convenient official tool [hexo-pagination] to easily build archi
 var pagination = require('hexo-pagination');
 
 hexo.extend.generator.register('archive', function(locals){
-  return pagination('archives/index.html', locals.posts, {
+  // hexo-pagination makes an index.html for the /archives route
+  return pagination('archives', locals.posts, {
     perPage: 10,
     layout: ['archive', 'index'],
     data: {}


### PR DESCRIPTION
`/archives/index.html/index.html`,
or in pretty format, `/archives/index.html/`.

tested with hexo-pagination 0.0.2.

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benifits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if interested this opputunity.
-->
