### PR TITLE
Documentation for the 'theme_config' setting

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -83,6 +83,7 @@ Setting | Description | Default
 Setting | Description
 --- | ---
 `theme` | Theme name. `false` disables theming
+`theme_config` | Theme configuration. Include any custom theme settings under this key to override theme defaults.
 `deploy` | Deployment setting
 
 
@@ -119,4 +120,33 @@ $ hexo server --config custom.yml,custom2.json
 Using multiple files combines all the config files and saves the merged settings to `_multiconfig.yml`. The later values take precedence. It works with any number of JSON and YAML files with arbitrarily deep objects. Note that **no spaces are allowed in the list**.
 
 For instance, in the above example if `foo: bar` is in `custom.yml`, but `"foo": "dinosaur"` is in `custom2.json`, `_multiconfig.yml` will contain `foo: dinosaur`.
+
+### Overriding Theme Config
+
+Hexo themes are independent projects, with separate `_config.yml` files.
+
+Instead of forking a theme, and maintaining a custom branch with your settings, you can configure it from your site's primary configuration file.
+
+Example configuration:
+
+```yml
+# _config.yml
+theme_config:
+  bio: "My awesome bio"
+```
+
+```yml
+# themes/my-theme/_config.yml
+bio: "Some generic bio"
+logo: "a-cool-image.png"
+```
+
+Resulting theme configuration:
+
+```json
+{
+  bio: "My awesome bio",
+  logo: "a-cool-image.png"
+}
+```
 


### PR DESCRIPTION
The `theme_config` setting, for configuring themes in the primary `_config.yml` file is extremely useful.
It doesn't appear in the documentation, so this commit adds it.

The example code is taken directly from the original pull request: https://github.com/hexojs/hexo/pull/757
