### PR TITLE
Add hexo-filter-responsive-images plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1852,3 +1852,12 @@
     - admin
     - editor
     - imagepicker
+
+- name: hexo-filter-responsive-images
+  description: Generate mutliple version of images for responsive blogs.
+  link: https://github.com/hexojs/hexo-responsive-images
+  tags:
+    - images
+    - responsive
+    - resize
+    - thumbnails


### PR DESCRIPTION
There are some plugins like this already but I think this one is worth adding because it's:
 - not depending on ImageMagick being installed
 - integrated with the routing, so it can be used with other plugins (like image minification)
 - lazy for `hexo server` - it resizes images only if requested
 - covered by specs
 - owned by hexojs organization