### PR TITLE
Update hexo-fontawesome plugin URL

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1840,7 +1840,7 @@
     - gitter
 - name: hexo-fontawesome
   description: A utility function which helps to inline Font Awesome SVG files.
-  link: https://github.com/ertrzyiks/hexo-fontawesome
+  link: https://github.com/hexojs/hexo-fontawesome
   tags:
     - helper
     - fontawesome


### PR DESCRIPTION
It has been moved to the hexojs organization, so the repo URL has changed as well.