### PR TITLE
add plugin hexo-auto-category

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1918,3 +1918,13 @@
     - preview
     - image
     - ogp
+- name: hexo-auto-category
+  description: Generates categories automatically by folder name
+  link: https://github.com/xu-song/hexo-auto-category
+  tags:
+    - auto
+    - generation
+    - categories
+    - folder
+    - directory
+    - structure


### PR DESCRIPTION
<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->

add `hexo-auto-category` to Plugin list

https://github.com/xu-song/hexo-auto-category

A Hexo plugin, which generates categories automatically from folder structure for each post.
