### PR TITLE
Update hexo-filter-responsive-images

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1883,7 +1883,7 @@
     - getforge
 - name: hexo-filter-responsive-images
   description: Generate mutliple version of images for responsive blogs.
-  link: https://github.com/hexojs/hexo-responsive-images
+  link: https://github.com/hexojs/hexo-filter-responsive-images
   tags:
     - images
     - responsive


### PR DESCRIPTION
Correct plugin link to 'hexo-filter-responsive-images'.
Link '.../hexo-responsive-images' doesn't exist.