### PR TITLE
Add hexo-generator-search-zip plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1949,3 +1949,11 @@
     - filter
     - hide
     - content
+- name: hexo-generator-search-zip
+  description: Compressed search data(zip) generator for Hexo.
+  link: https://github.com/SuperKieran/hexo-generator-search-zip
+  tags:
+    - search
+    - generator
+    - zip
+    - compress

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1942,6 +1942,14 @@
   tags:
     - official
     - deployer
+- name: hexo-generator-search-zip
+  description: Compressed search data (zip) generator for Hexo.
+  link: https://github.com/SuperKieran/hexo-generator-search-zip
+  tags:
+    - search
+    - generator
+    - zip
+    - compress
 - name: hexo-filter-hide-content
   description: Hide some content for Hexo.
   link: https://github.com/mmhy/hexo-filter-hide-content
@@ -1949,11 +1957,3 @@
     - filter
     - hide
     - content
-- name: hexo-generator-search-zip
-  description: Compressed search data(zip) generator for Hexo.
-  link: https://github.com/SuperKieran/hexo-generator-search-zip
-  tags:
-    - search
-    - generator
-    - zip
-    - compress


### PR DESCRIPTION
Generate zip search data for Hexo 3.0. This plugin is used for generating a search index file, which contains all the neccessary data of your articles that you can use to write a local search engine for your blog.
