### PR TITLE
Add hexo-filter-lqip

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1949,3 +1949,10 @@
     - filter
     - hide
     - content
+- name: hexo-filter-lqip
+  description: Generate Low-Quality Image Placeholders for lazy loaded images in themes
+  link: https://github.com/hexojs/hexo-filter-lqip
+  tags:
+    - images
+    - placeholder
+    - optimize


### PR DESCRIPTION
This is a plugin requires an extra integration with a theme, so it's intended for theme authors. For now it only generates low-quality SVGs using potrace, but there is more to come soon-ish.

Inspired by [Using SVG as placeholders ](https://jmperezperez.com/svg-placeholders/)