### PR TITLE
Add plugin: hexo-tag-autogallery

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1984,3 +1984,10 @@
     - renderer
     - js
     - webpack
+- name: hexo-tag-autogallery
+  description: Generates automatically a gallery from provided directory's contents and using given layout.
+  link: https://www.npmjs.com/package/hexo-tag-autogallery
+  tags:
+    - tag
+    - gallery
+    - autogallery


### PR DESCRIPTION
This PR adds my plugin, `hexo-tag-autogallery` to the lists of available plugins.

`hexo-tag-autogallery` is a tag plugin that generates automatically photo gallery from contents of provided directory and using given template.

https://www.npmjs.com/package/hexo-tag-autogallery