### PR TITLE
Fix broken theme preview link

### DIFF
--- a/source/_data/themes.yml
+++ b/source/_data/themes.yml
@@ -1034,7 +1034,7 @@
 - name: beautiful-hexo
   description: A simple responsive beautiful theme.
   link: https://github.com/twoyao/beautiful-hexo
-  preview: http://twoyao.cn/beautiful-hexo/
+  preview: http://twoyao.github.io/beautiful-hexo/
   tags:
     - responsive
     - beautiful


### PR DESCRIPTION
I'm the author of theme "beautiful-hexo". Since my custom domain no longer points to github.io, here is the fix.