### PR TITLE
hexo-tag-garminconnect plugin added

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2015,3 +2015,6 @@
     - activity
     - running
     - cycling
+    - gis
+    - gps
+

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2004,3 +2004,14 @@
   tags:
     - tag
     - codepen
+- name: hexo-tag-garminconnect
+  description: Embed Garmin connect activity in your blog.
+  link: https://github.com/alexmufatti/hexo-tag-garminconnect
+  tags:
+    - tag_plugins
+    - garmin
+    - connect
+    - sport
+    - activity
+    - running
+    - cycling


### PR DESCRIPTION
Simply added a new plugin to the plugin list.
This plugin let you embed a Garmin connect activity in your hexo blog.
