### PR TITLE
Fix link to warehouse repository and doc

### DIFF
--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -190,6 +190,6 @@ plugins:
   - hexo-generator-sitemap
 ```
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/

--- a/source/docs/variables.md
+++ b/source/docs/variables.md
@@ -65,7 +65,7 @@ Variable | Description | Type
 `page.total` | Total number of pages | `number`
 `page.current` | Current page number | `number`
 `page.current_url` | The URL of current page | `string`
-`page.posts` | Posts in this page ([Data Model](https://hexo.io/warehouse/)) | `object`
+`page.posts` | Posts in this page ([Data Model](https://hexojs.github.io/warehouse/)) | `object`
 `page.prev` | Previous page number. `0` if the current page is the first. | `number`
 `page.prev_link` | The URL of previous page. `''` if the current page is the first. | `string`
 `page.next` | Next page number. `0` if the current page is the last. | `number`

--- a/source/ko/docs/troubleshooting.md
+++ b/source/ko/docs/troubleshooting.md
@@ -128,6 +128,6 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 ```
 이 명령어는 감시(watch)할 수 있는 파일의 개수 제한을 증가시킵니다.
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/

--- a/source/pt-br/docs/troubleshooting.md
+++ b/source/pt-br/docs/troubleshooting.md
@@ -177,6 +177,6 @@ plugins:
   - hexo-generator-sitemap
 ```
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/

--- a/source/pt-br/docs/variables.md
+++ b/source/pt-br/docs/variables.md
@@ -65,7 +65,7 @@ Variável | Descrição | Tipo
 `page.total` | Número total de páginas | `number`
 `page.current` | Número da página atual | `number`
 `page.current_url` | A URL da página atual | `string`
-`page.posts` | Posts in this page ([Data Model](https://hexo.io/warehouse/)) | 
+`page.posts` | Posts in this page ([Data Model](https://hexojs.github.io/warehouse/)) | 
 `page.prev` | Número da página anterior. `0` se a página atual for a primeira. | `number`
 `page.prev_link` | A URL da página anterior. `''` se a página atual for a primeira. | `string`
 `page.next` | Número da próxima página. `0` se a página atual for a última. | `number`

--- a/source/ru/docs/troubleshooting.md
+++ b/source/ru/docs/troubleshooting.md
@@ -134,6 +134,6 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 
 Это позволит увеличить лимит количества файлов, которые можно просматривать одновременно.
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/

--- a/source/zh-cn/docs/troubleshooting.md
+++ b/source/zh-cn/docs/troubleshooting.md
@@ -115,7 +115,7 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 ```
 这将会提高你能监视的文件数量。
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/
 

--- a/source/zh-tw/docs/troubleshooting.md
+++ b/source/zh-tw/docs/troubleshooting.md
@@ -87,6 +87,6 @@ Hello {{ sensitive }}
 {% endraw %}
 ```
 
-[Warehouse]: https://github.com/tommy351/warehouse
+[Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
 [Nunjucks]: http://mozilla.github.io/nunjucks/


### PR DESCRIPTION
* DataModel link (https://hexo.io/warehouse/) is broken.
* And update warehouse repository link.
