### PR TITLE
3.8.0 release note

### DIFF
--- a/source/_posts/2018-10-19-hexo-3-8-released.md
+++ b/source/_posts/2018-10-19-hexo-3-8-released.md
@@ -1,0 +1,29 @@
+---
+title: Hexo 3.8.0 Released
+---
+
+## New feature
+
+* Supported absolute config path [#3118]
+* Added command line option `--output` to write `db.json` and `_multiconfig` to different paths [#3122]
+* Added meta generator injection filter [#3129]
+
+## Housekeeping
+[#3124], [#3117], [#3102], [#3276], [#3284], [#3285], [#3290], [#3293]
+
+More info: [changelog]
+
+[changelog]: https://github.com/hexojs/hexo/releases
+[#3124]: https://github.com/hexojs/hexo/issues/3124
+[#3117]: https://github.com/hexojs/hexo/issues/3117
+
+[#3118]: https://github.com/hexojs/hexo/issues/3118
+[#3122]: https://github.com/hexojs/hexo/issues/3122
+[#3129]: https://github.com/hexojs/hexo/issues/3129
+
+[#3102]: https://github.com/hexojs/hexo/issues/3102
+[#3276]: https://github.com/hexojs/hexo/issues/3276
+[#3284]: https://github.com/hexojs/hexo/issues/3284
+[#3285]: https://github.com/hexojs/hexo/issues/3285
+[#3290]: https://github.com/hexojs/hexo/issues/3290
+[#3293]: https://github.com/hexojs/hexo/issues/3293

--- a/source/_posts/2018-10-19-hexo-3-8-released.md
+++ b/source/_posts/2018-10-19-hexo-3-8-released.md
@@ -16,11 +16,9 @@ More info: [changelog]
 [changelog]: https://github.com/hexojs/hexo/releases
 [#3124]: https://github.com/hexojs/hexo/issues/3124
 [#3117]: https://github.com/hexojs/hexo/issues/3117
-
 [#3118]: https://github.com/hexojs/hexo/issues/3118
 [#3122]: https://github.com/hexojs/hexo/issues/3122
 [#3129]: https://github.com/hexojs/hexo/issues/3129
-
 [#3102]: https://github.com/hexojs/hexo/issues/3102
 [#3276]: https://github.com/hexojs/hexo/issues/3276
 [#3284]: https://github.com/hexojs/hexo/issues/3284


### PR DESCRIPTION
[Official page news](https://hexo.io/news/)  is no longer update.
Hexo does not seem to be updated from the users. It is not good.

I wrote 3.8.0 release note.
It only copy from [hexo main repository](https://github.com/hexojs/hexo/releases/tag/3.8.0). Not write detail. But, better than nothing.

Of course I already checked work well on my local machine.