### PR TITLE
Add plugins: hexo-yam and hexo-nofollow

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2110,3 +2110,10 @@
     - compress
     - gzip
     - brotli
+- name: hexo-nofollow
+  description: Add SEO-friendly nofollow attribute to all external links in your posts. A more updated version of hexo-autonofollow.
+  link: https://github.com/weyusi/hexo-nofollow
+  tags:
+    - SEO
+    - nofollow
+    - external

--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2098,3 +2098,15 @@
     - highlight
     - code
     - vim
+- name: hexo-yam
+  description: Yet Another Minifier. Minify and compress html, js and css. Support gzip and brotli compressions.
+  link: https://github.com/weyusi/hexo-yam
+  tags:
+    - filter
+    - minify
+    - html
+    - js
+    - css
+    - compress
+    - gzip
+    - brotli


### PR DESCRIPTION
This pull adds new plugins to the catalog, [hexo-yam](https://github.com/weyusi/hexo-yam) and [hexo-nofollow](https://github.com/weyusi/hexo-nofollow).

hexo-yam: Minify and compress html, js and css. Support gzip and brotli compressions.
hexo-nofollow: Adds nofollow attribute to all external links in posts. A more updated version of [hexo-autonofollow](https://github.com/liuzc/hexo-autonofollow).