### PR TITLE
post_path and post_link use filename not post.title

### DIFF
--- a/source/docs/tag-plugins.md
+++ b/source/docs/tag-plugins.md
@@ -219,15 +219,32 @@ Inserts a Vimeo video.
 Include links to other posts.
 
 ```
-{% post_path slug %}
-{% post_link slug [title] %}
+{% post_path filename %}
+{% post_link filename [optional text] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag. 
 
 For instance: `{% raw %}{% post_link how-to-bake-a-cake %}{% endraw %}`.
 
-This will work as long as the post has in the front matter `title: How to bake a cake`, even if the post is located at `source/posts/2015-02-my-family-holiday` and has permalink `2018/en/how-to-bake-a-cake`.
+This will work as long as the filename of the post is `how-to-bake-a-cake.md`, even if the post is located at `source/posts/2015-02-my-family-holiday` and has permalink `2018/en/how-to-bake-a-cake`.
+
+You can customize the text to display, instead of displaying the post's title. Using `post_path` inside Markdown syntax `[]()` is not supported.
+
+For instance:
+
+**Display title of the post.**
+
+`{% raw %}{% post_link 2018-10-19-hexo-3-8-released %}{% endraw %}`
+
+{% post_link 2018-10-19-hexo-3-8-released %}
+
+**Display custom text.**
+
+`{% raw %}{% post_link 2018-10-19-hexo-3-8-released 'Link to a post' %}{% endraw %}`
+
+{% post_link 2018-10-19-hexo-3-8-released 'Link to a post' %}
+
 
 ## Include Assets
 


### PR DESCRIPTION
The title in front matter (or post.title) is not necessarily similar to the filename of the post. The difference could occur when user prefers to create a post manually, instead of `$ hexo new [layout] <title>`.

I also replaced `slug` with more common `filename`.

## Test
1. Using post title:
```
{% post_path old-post-is-ancient %}

Testing a <a href="{% post_path old-post-is-ancient %}">link</a>.

{% post_link old-post-is-ancient %}
```
    

rendered as:

```html
<p>Testing a <a href="">link</a>.</p>
```

https://github.com/weyusi/hexo-testing/blob/9bbd4643ab7149f516d20293c77574d56c0efc0e/2018/11/01/test-post/index.html#L77-L79

2. Using file name:
```
{% post_path old-post %}

Testing a <a href="{% post_path old-post %}">link</a>.

{% post_link old-post %}
```

rendered as:

```html
/hexo-testing/2018/10/15/old-post/
<p>Testing a <a href="/hexo-testing/2018/10/15/old-post/">link</a>.</p>
<a href="/hexo-testing/2018/10/15/old-post/" title="Old post is ancient">Old post is ancient</a>
```

https://github.com/weyusi/hexo-testing/blob/9bbd4643ab7149f516d20293c77574d56c0efc0e/2018/11/01/test-post/index.html#L83-L85

---

Related to https://github.com/hexojs/hexo/issues/1594.