### PR TITLE
chore(doc): delete link to hexojs.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- Markdown snippet -->
 [![Build Status](https://travis-ci.org/hexojs/site.svg?branch=master)](https://travis-ci.org/hexojs/site)
 
-The website for Hexo. You can see the generated files at [hexojs/hexojs.github.io](https://github.com/hexojs/hexojs.github.io) repository.
+The website for Hexo.
 
 ## Getting started
 


### PR DESCRIPTION
## Proposal

Delete link to [hexojs/hexojs.github.io](https://github.com/hexojs/hexojs.github.io) in README.

## Reason

The [hexojs/hexojs.github.io](https://github.com/hexojs/hexojs.github.io) has already not update after migrate to Netlify.

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
