### PR TITLE
chore: compress images upon commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,17 @@
     "gulp-uglify": "^1.5.3",
     "gulp-unique-files": "^0.1.2",
     "gulp-useref": "^2.1.0",
+    "husky": "^1.1.3",
+    "imagemin-lint-staged": "^0.3.0",
+    "lint-staged": "^8.0.4",
     "rename": "^1.0.4"
+  },
+  "husky": {
+    "hooks": {  
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{png,jpeg,jpg,gif,svg}": ["imagemin-lint-staged", "git add"]
   }
 }


### PR DESCRIPTION
suggested by https://github.com/hexojs/site/pull/796#issuecomment-433789961

this pull will only affect new images, current ones have been compressed (https://github.com/hexojs/site/pull/796).
