### PR TITLE
gulp.useRef.assets is no longer used

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,18 +20,14 @@ var dirs = {
 };
 
 gulp.task('useref', ['screenshot'], function() {
-  var assets = gulpUseRef.assets({
-    searchPath: 'public'
-  });
-
   return gulp.src('public/**/*.html')
-    .pipe(assets)
     .pipe(gulpUniqueFiles())
     .pipe(gulpIf('*.css', gulpCleanCSS()))
     .pipe(gulpIf('*.js', gulpUglify()))
     .pipe(gulpRev())
-    .pipe(assets.restore())
-    .pipe(gulpUseRef())
+    .pipe(gulpUseRef({
+      searchPath: 'public'
+    }))
     .pipe(gulpRevReplace({
       prefix: '/'
     }))


### PR DESCRIPTION
- [x] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
