### PR TITLE
chore(plugin): add hexo-nanoid plugin.

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2146,3 +2146,9 @@
     - webhook
     - generate
     - git
+- name: hexo-nanoid
+  description: Use popular NanoID to generate abbreviated post links.
+  link: https://github.com/cowsay-blog/hexo-nanoid
+  tags:
+    - permalink
+    - link


### PR DESCRIPTION
- [x] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
---
## Description
Yet another permalink plugin that exploits [ai/nanoid](https://github.com/ai/nanoid) to generate abbreviated post links.

The plugin provides configurable character set and ID length and performs ID validation and uniqueness check before route generation and while creating new post via `hexo new`.