### PR TITLE
fix: generated image link jpg to jpeg

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,7 @@ gulp.task('screenshot:revreplace', ['screenshot:rev'], function() {
         var src = img.attr('data-src') || img.attr('data-org');
         if (!src) return;
 
-        var jpgPath = replaceBackSlash(rename(src, {extname: '.jpg'}));
+        var jpgPath = replaceBackSlash(rename(src, {extname: '.jpeg'}));
         var jpg2xPath = replaceBackSlash(rename(jpgPath, {suffix: '@2x'}));
         var srcset = [
           jpgPath,


### PR DESCRIPTION
@hexojs/core 
IMHO, this issue is high priority issue. Could you please review & merge this?

### Problem

Hexo official site [themes](https://hexo.io/themes/) preview images can not see.

### Reason

In html src image link extension is `jpg`. But, acturally (generated by gulp) image extension is `jpeg`. Please see below two images. 

![issue](https://user-images.githubusercontent.com/11273093/54293439-552ea300-45f3-11e9-9084-edcbf40cfecb.png)

![issue2](https://user-images.githubusercontent.com/11273093/54293641-b35b8600-45f3-11e9-81df-3821de4669bd.png)

### Others

Btw, I believe this issue caused by dependency package version. I propose include `package-lock.json`

Thanks