### PR TITLE
Revert "fix: generated image link jpg to jpeg (#911)"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,7 @@ gulp.task('screenshot:revreplace', ['screenshot:rev'], function() {
         var src = img.attr('data-src') || img.attr('data-org');
         if (!src) return;
 
-        var jpgPath = replaceBackSlash(rename(src, {extname: '.jpeg'}));
+        var jpgPath = replaceBackSlash(rename(src, {extname: '.jpg'}));
         var jpg2xPath = replaceBackSlash(rename(jpgPath, {suffix: '@2x'}));
         var srcset = [
           jpgPath,


### PR DESCRIPTION
## Problem

In (#911),  I changed the image file link extension in the HTML. It worked well after deploy.
But, now it's broken again.

Gulp file generate `jpeg` file certenly.

![gulp](https://user-images.githubusercontent.com/11273093/54527989-ebc9de00-49be-11e9-995b-f41d0ce7daa1.png)

But, it does not exist in the current web site theme page.

![jpeg notexist](https://user-images.githubusercontent.com/11273093/54528014-02703500-49bf-11e9-89b8-98f757949f87.jpg)

`jpg` file is exist instead of `jpeg` file.

![exists](https://user-images.githubusercontent.com/11273093/54528073-2c295c00-49bf-11e9-9325-e2b972b2c065.jpg)

## Solution

I reverted (#911)

It's so sorry... It is possibility that my fault.