### PR TITLE
fix(theme): change link of Raytaylorism themes

### DIFF
--- a/source/_data/themes.yml
+++ b/source/_data/themes.yml
@@ -940,7 +940,7 @@
 - name: Raytaylorism
   description: A Material Design theme of with powerful features
   link: https://github.com/raytaylorlin/hexo-theme-raytaylorism
-  preview: http://raytaylorlin.com/
+  preview: https://raytaylorlin.github.io/
   tags:
     - material
     - responsive


### PR DESCRIPTION
From https://github.com/hexojs/hexo/issues/3520 issue.
I updated link of theme.

