### PR TITLE
chore(gulp): upgrade to v4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ var dirs = {
   screenshots: 'public/build/screenshots'
 };
 
-gulp.task('useref', ['screenshot'], function() {
+gulp.task('useref', function() {
   return gulp.src('public/**/*.html')
     .pipe(gulpUniqueFiles())
     .pipe(gulpIf('*.css', gulpCleanCSS()))
@@ -34,11 +34,11 @@ gulp.task('useref', ['screenshot'], function() {
     .pipe(gulp.dest('public'));
 });
 
-gulp.task('screenshot:clean', function() {
+gulp.task('clean', function() {
   return del([dirs.screenshots + '/**/*']);
 });
 
-gulp.task('screenshot:rev', ['screenshot:clean'], function() {
+gulp.task('rev', function() {
   return gulp.src('public/themes/screenshots/*.png')
     .pipe(gulpRev())
     .pipe(gulp.dest(dirs.screenshots))
@@ -46,7 +46,7 @@ gulp.task('screenshot:rev', ['screenshot:clean'], function() {
     .pipe(gulp.dest(dirs.screenshots));
 });
 
-gulp.task('screenshot:revreplace', ['screenshot:rev'], function() {
+gulp.task('revreplace', function() {
   var destDir = '/build/screenshots';
 
   return gulp.src([dirs.screenshots + '/rev-manifest.json', 'public/themes/index.html'])
@@ -77,7 +77,7 @@ gulp.task('screenshot:revreplace', ['screenshot:rev'], function() {
     .pipe(gulp.dest('public/themes'));
 });
 
-gulp.task('screenshot:resize', ['screenshot:rev'], function() {
+gulp.task('resize', function() {
   return gulp.src(dirs.screenshots + '/*.png')
     .pipe(gulpResponsive({
       '*.png': [
@@ -103,8 +103,8 @@ gulp.task('screenshot:resize', ['screenshot:rev'], function() {
     .pipe(gulp.dest(dirs.screenshots));
 });
 
-gulp.task('screenshot', ['screenshot:rev', 'screenshot:resize', 'screenshot:revreplace']);
-gulp.task('default', ['useref', 'screenshot']);
+gulp.task('default',
+  gulp.series('clean', 'rev', gulp.parallel('resize', 'revreplace'), 'useref'));
 
 function replaceBackSlash(str) {
   return str.replace(/\\/g, '/');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,20 +1,20 @@
 'use strict';
 
-var gulp = require('gulp');
-var gulpIf = require('gulp-if');
-var gulpRev = require('gulp-rev');
-var gulpRevCollector = require('gulp-rev-collector');
-var gulpRevReplace = require('gulp-rev-replace');
-var gulpUglify = require('gulp-uglify');
-var gulpUniqueFiles = require('gulp-unique-files');
-var gulpUseRef = require('gulp-useref');
-var gulpCleanCSS = require('gulp-clean-css');
-var gulpResponsive = require('gulp-responsive');
-var gulpCheerio = require('gulp-cheerio');
-var del = require('del');
-var rename = require('rename');
+const gulp = require('gulp');
+const gulpIf = require('gulp-if');
+const gulpRev = require('gulp-rev');
+const gulpRevCollector = require('gulp-rev-collector');
+const gulpRevReplace = require('gulp-rev-replace');
+const gulpUglify = require('gulp-uglify');
+const gulpUniqueFiles = require('gulp-unique-files');
+const gulpUseRef = require('gulp-useref');
+const gulpCleanCSS = require('gulp-clean-css');
+const gulpResponsive = require('gulp-responsive');
+const gulpCheerio = require('gulp-cheerio');
+const del = require('del');
+const rename = require('rename');
 
-var dirs = {
+const dirs = {
   public: 'public',
   screenshots: 'public/build/screenshots'
 };
@@ -47,7 +47,7 @@ gulp.task('rev', function() {
 });
 
 gulp.task('revreplace', function() {
-  var destDir = '/build/screenshots';
+  const destDir = '/build/screenshots';
 
   return gulp.src([dirs.screenshots + '/rev-manifest.json', 'public/themes/index.html'])
     .pipe(gulpRevCollector({
@@ -58,13 +58,13 @@ gulp.task('revreplace', function() {
     }))
     .pipe(gulpCheerio(function($, file) {
       $('img.plugin-screenshot-img.lazyload').each(function() {
-        var img = $(this);
-        var src = img.attr('data-src') || img.attr('data-org');
+        const img = $(this);
+        const src = img.attr('data-src') || img.attr('data-org');
         if (!src) return;
 
-        var jpgPath = replaceBackSlash(rename(src, {extname: '.jpeg'}));
-        var jpg2xPath = replaceBackSlash(rename(jpgPath, {suffix: '@2x'}));
-        var srcset = [
+        const jpgPath = replaceBackSlash(rename(src, {extname: '.jpeg'}));
+        const jpg2xPath = replaceBackSlash(rename(jpgPath, {suffix: '@2x'}));
+        const srcset = [
           jpgPath,
           jpg2xPath + ' 2x'
         ].join(', ');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "del": "^4.0.0",
     "eslint": "^5.10.0",
     "eslint-config-hexo": "^3.0.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "gulp-cheerio": "^0.6.2",
     "gulp-clean-css": "^4.0.0",
     "gulp-if": "^2.0.0",


### PR DESCRIPTION
Closes #839 ?

Previous execution chain:
```
default
  useref
    screenshot
  screenshot
    rev
      clean
    resize
      rev
    revreplace
      rev
```
The order is reversed (sort of) in Gulp@4.

https://fettblog.eu/gulp-4-parallel-and-series/
- [x] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
