### PR TITLE
Add hexo-tag-qrcode plugin

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2230,3 +2230,9 @@
     - tag
     - details
     - summary
+- name: hexo-tag-qrcode
+  description: A Hexo plugin that generates a qrcode image and inserts it into a post.
+  link: https://github.com/jsweibo/hexo-tag-qrcode
+  tags:
+    - tag
+    - qrcode


### PR DESCRIPTION
A Hexo plugin that generates a qrcode image and inserts it into a post.

- [x] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
