### PR TITLE
Hexo 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.8.0"
+    "version": "3.9.0"
   },
   "scripts": {
     "build": "hexo generate && gulp",

--- a/source/_posts/2019-06-19-hexo-3-9-released.md
+++ b/source/_posts/2019-06-19-hexo-3-9-released.md
@@ -1,0 +1,47 @@
+---
+title: Hexo 3.9.0 Released
+---
+
+## New Features
+
+* Updated hexo-renderer-marked to 1.0.1 [#3571]
+* Updated hexo-fs to 1.0.0 [#3301]
+* TOC: Seek anchor id from parent nodes when target is not available [#3404]
+* tag/include_code now can include ranged code lines [#3393]
+
+## Bug Fixes
+
+* DisableNunjucks: true should render markdown code block [#3573]
+* Changing source config should generate assets [#3399]
+
+## Refactor
+
+* Spread function: Hexo built-in plugin blockquote [#3291]
+* ES6 block scoping refactor [#3294]
+* Use spread syntax [#3333]
+
+## Housekeeping
+
+[#3326], [#3324], [#3315], [#3300], [#3329], [#3359], [#3369], [#3368], [#3367], [#3569]
+
+More info: [changelog]
+
+[changelog]: https://github.com/hexojs/hexo/releases
+[#3571]: https://github.com/hexojs/hexo/issues/3571
+[#3301]: https://github.com/hexojs/hexo/issues/3301
+[#3404]: https://github.com/hexojs/hexo/issues/3404
+[#3573]: https://github.com/hexojs/hexo/issues/3573
+[#3399]: https://github.com/hexojs/hexo/issues/3399
+[#3291]: https://github.com/hexojs/hexo/issues/3291
+[#3294]: https://github.com/hexojs/hexo/issues/3294
+[#3333]: https://github.com/hexojs/hexo/issues/3333
+[#3326]: https://github.com/hexojs/hexo/issues/3326
+[#3324]: https://github.com/hexojs/hexo/issues/3324
+[#3315]: https://github.com/hexojs/hexo/issues/3315
+[#3300]: https://github.com/hexojs/hexo/issues/3300
+[#3329]: https://github.com/hexojs/hexo/issues/3329
+[#3359]: https://github.com/hexojs/hexo/issues/3359
+[#3369]: https://github.com/hexojs/hexo/issues/3369
+[#3368]: https://github.com/hexojs/hexo/issues/3368
+[#3367]: https://github.com/hexojs/hexo/issues/3367
+[#3569]: https://github.com/hexojs/hexo/issues/3569


### PR DESCRIPTION
- [ ] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing). (not applicable)

Based on release note of https://github.com/hexojs/hexo/releases/tag/3.9.0 .