### PR TITLE
chore(ci): add node 8 and latest stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: node_js
 sudo: false
 
 node_js:
+  - "8"
   - "10"
+  - "node"
 
 cache:
   apt: true


### PR DESCRIPTION
Previously there was an incompatibility issue between Node versions and Nunjucks (#798). This is now resolved in Nunjucks >= 3.1.5, i.e. it doesn't specify max Node version anymore (https://github.com/mozilla/nunjucks/commit/fb3f443514cb90d0dfa4d8af50b11a794f6548ee#diff-b9cfc7f2cdf78a7f4b91a753d10865a2).

Add node 8 and the latest stable (v12 atm) to have more thorough tests and in line with the main hexo.

Closes #798