### PR TITLE
docs: add a guide to fix EACCES permissions error

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -32,6 +32,10 @@ If not, please follow the following instructions to install all the requirements
 You may encounter some problems when compiling. Please install Xcode from App Store first. After Xcode is installed, open Xcode and go to **Preferences -> Download -> Command Line Tools -> Install** to install command line tools.
 {% endnote %}
 
+{% note warn For Mac / Linux users %}
+If you are a macOS user, or a Linux user who install Node.js through your package manager with default repository, you might run into some permission error when using `npm install -g`. Please follow [the guide provided by npmjs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) to solve the issue, AND DO NOT USE ROOT USER OR SUDO TO OVERRIDE.
+{% endnote %}
+
 ### Install Git
 
 - Windows: Download & install [git](https://git-scm.com/download/win).
@@ -62,7 +66,7 @@ Once nvm is installed, restart the terminal and run the following command to ins
 $ nvm install stable
 ```
 
-Alternatively, download and run [the installer](http://nodejs.org/). Most Linux distributions  ship Node.js in their default repository. [NodeSource](https://github.com/nodesource/distributions) third-party repo usually ships more up-to-date Node.js.
+Alternatively, download and run [the installer](http://nodejs.org/). Most Linux distributions ship Node.js in their default repository. [NodeSource](https://github.com/nodesource/distributions) third-party repo usually ships more up-to-date Node.js.
 
 ### Install Hexo
 

--- a/source/zh-cn/docs/index.md
+++ b/source/zh-cn/docs/index.md
@@ -33,6 +33,10 @@ $ npm install -g hexo-cli
 您在编译时可能会遇到问题，请先到 App Store 安装 Xcode，Xcode 完成后，启动并进入 **Preferences -> Download -> Command Line Tools -> Install** 安装命令行工具。
 {% endnote %}
 
+{% note warn For Mac / Linux 用户 %}
+如果你是 macOS 用户，或者是通过软件管理器从默认软件仓库安装 Node.js 的 Linux 用户，在使用 npm 的 `-g` 参数时可能会遇到一些权限相关的问题。请遵循 [由 npmjs 发布的指导](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) 修复该问题，**并且不要使用 root、sudo 等方法覆盖权限**
+{% endnote %}
+
 ### 安装 Git
 
 - Windows：下载并安装 [git](https://git-scm.com/download/win).


### PR DESCRIPTION
- [ ] Read the [theme publishing doc](https://hexo.io/docs/themes#Publishing) or [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->

I have noticed some user comment at Hexo documents installation guide said they ran into trouble with `EACCES permissions errors` when execute `npm i hexo-cli -g`

npmjs has released a guide to solve that issue: https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally
