### PR TITLE
Adding a new Markdown renderer

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -370,6 +370,15 @@
     - renderer
     - markdown
     - kramed
+- name: hexo-renderer-unified
+  description: Markdown renderer plugin for Hexo - based on Unified.
+  link: https://github.com/TitiAlone/hexo-renderer-unified
+  tags:
+    - renderer
+    - markdown
+    - unified
+    - remark
+    - rehype
 - name: hexo-autoprefixer
   description: Autoprefixer plugin for Hexo.
   link: https://github.com/hexojs/hexo-autoprefixer


### PR DESCRIPTION
Hello,

I've created a new renderer for Hexo based on remark and rehype; may I integrate it into the plugin list?

The new renderer is very nice as it embed code highlighting, line numbering for codes, and math rendering by default with a simple configuration option; maybe some people would be interested ;) .