### PR TITLE
docs(helpers): type attribute is no longer added

### DIFF
--- a/source/api/helper.md
+++ b/source/api/helper.md
@@ -16,13 +16,13 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```
 
 ## FAQ

--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -61,11 +61,11 @@ Loads CSS files. `path` can be an array or a string. If `path` isn't prefixed wi
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -80,11 +80,11 @@ Loads JavaScript files. `path` can be an array or a string. If `path` isn't pref
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/ko/api/helper.md
+++ b/source/ko/api/helper.md
@@ -15,11 +15,11 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```

--- a/source/ko/docs/helpers.md
+++ b/source/ko/docs/helpers.md
@@ -57,11 +57,11 @@ CSS 파일들을 불러옵니다. `path`에는 문자열(string) 또는 배열(a
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -76,11 +76,11 @@ JavaScript 파일들을 불러옵니다. `path`에는 문자열(string) 또는 �
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/pt-br/api/helper.md
+++ b/source/pt-br/api/helper.md
@@ -18,13 +18,13 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```
 
 ## FAQ

--- a/source/pt-br/docs/helpers.md
+++ b/source/pt-br/docs/helpers.md
@@ -62,11 +62,11 @@ Carrega arquivos CSS. Onde `path` pode ser um array ou uma string. Se `path` nã
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -81,11 +81,11 @@ Carrega arquivos JavaScript. O `path` pode ser uma array ou uma string. Se `path
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/ru/api/helper.md
+++ b/source/ru/api/helper.md
@@ -15,11 +15,11 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```

--- a/source/ru/docs/helpers.md
+++ b/source/ru/docs/helpers.md
@@ -57,11 +57,11 @@ title: Помощники
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -76,11 +76,11 @@ title: Помощники
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/th/api/helper.md
+++ b/source/th/api/helper.md
@@ -15,13 +15,13 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```
 
 ## FAQ

--- a/source/th/docs/helpers.md
+++ b/source/th/docs/helpers.md
@@ -69,11 +69,11 @@ object นั้นจะถูกเปลี่ยนไปเป็น query 
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -91,11 +91,11 @@ object นั้นจะถูกเปลี่ยนไปเป็น query 
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/zh-cn/api/helper.md
+++ b/source/zh-cn/api/helper.md
@@ -14,13 +14,13 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```
 
 ## FAQ

--- a/source/zh-cn/docs/helpers.md
+++ b/source/zh-cn/docs/helpers.md
@@ -57,11 +57,11 @@ title: 辅助函数（Helpers）
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -76,11 +76,11 @@ title: 辅助函数（Helpers）
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to

--- a/source/zh-tw/api/helper.md
+++ b/source/zh-tw/api/helper.md
@@ -15,11 +15,11 @@ hexo.extend.helper.register(name, function(){
 
 ``` js
 hexo.extend.helper.register('js', function(path){
-  return '<script type="text/javascript" src="' + path + '"></script>';
+  return '<script src="' + path + '"></script>';
 });
 ```
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="script.js"></script>
+// <script src="script.js"></script>
 ```

--- a/source/zh-tw/docs/helpers.md
+++ b/source/zh-tw/docs/helpers.md
@@ -56,11 +56,11 @@ title: 輔助函數（Helpers）
 
 ``` js
 <%- css('style.css') %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
 
 <%- css(['style.css', 'screen.css']) %>
-// <link rel="stylesheet" href="/style.css" type="text/css">
-// <link rel="stylesheet" href="/screen.css" type="text/css">
+// <link rel="stylesheet" href="/style.css">
+// <link rel="stylesheet" href="/screen.css">
 ```
 
 ### js
@@ -75,11 +75,11 @@ title: 輔助函數（Helpers）
 
 ``` js
 <%- js('script.js') %>
-// <script type="text/javascript" src="/script.js"></script>
+// <script src="/script.js"></script>
 
 <%- js(['script.js', 'gallery.js']) %>
-// <script type="text/javascript" src="/script.js"></script>
-// <script type="text/javascript" src="/gallery.js"></script>
+// <script src="/script.js"></script>
+// <script src="/gallery.js"></script>
 ```
 
 ### link_to


### PR DESCRIPTION
## Check List
- [x] Others (Update, fix, translation, etc...)

[`js()`](https://github.com/hexojs/hexo/blob/master/lib/plugins/helper/js.js) and [`css()`](https://github.com/hexojs/hexo/blob/master/lib/plugins/helper/css.js) helpers no longer add type attribute, [nor necessary](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types).