### PR TITLE
highlight documentation

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -65,11 +65,11 @@ Setting | Description | Default
 `post_asset_folder` | Enable the [Asset Folder](asset-folders.html)? | `false`
 `relative_link` | Make links relative to the root folder? | `false`
 `future` | Display future posts? | `true`
-`highlight` | Code block syntax highlight settings, by default this feature is powered by the highlight.js library |
+`highlight` | Code block syntax highlight settings, powered by [highlight.js](https://highlightjs.org/) |
 `highlight.enable` | Enable syntax highlight | `true`
 `highlight.auto_detect` | Enable auto-detection if no language is specified | `false`
 `highlight.line_number` | Display line number | `true`
-`highlight.tab_replace` | ??? | `''`
+`highlight.tab_replace` | Replace tabs by n space(s), if the string is empty tabs won't be replaced | `''`
 
 
 

--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -65,7 +65,13 @@ Setting | Description | Default
 `post_asset_folder` | Enable the [Asset Folder](asset-folders.html)? | `false`
 `relative_link` | Make links relative to the root folder? | `false`
 `future` | Display future posts? | `true`
-`highlight` | Code block settings |
+`highlight` | Code block syntax highlight settings, by default this feature is powered by the highlight.js library |
+`highlight.enable` | Enable syntax highlight | `true`
+`highlight.auto_detect` | Enable auto-detection if no language is specified | `false`
+`highlight.line_number` | Display line number | `true`
+`highlight.tab_replace` | ??? | `''`
+
+
 
 ### Category & Tag
 

--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -69,8 +69,7 @@ Setting | Description | Default
 `highlight.enable` | Enable syntax highlight | `true`
 `highlight.auto_detect` | Enable auto-detection if no language is specified | `false`
 `highlight.line_number` | Display line number | `true`
-`highlight.tab_replace` | Replace tabs by n space(s), if the string is empty tabs won't be replaced | `''`
-
+`highlight.tab_replace` | Replace tabs by n space(s); if the value is empty, tabs won't be replaced | `''`
 
 
 ### Category & Tag


### PR DESCRIPTION
Address issue https://github.com/hexojs/hexo/issues/3688

WIP: I imagine the description for `highlight.tab_replace` is something like *Replace tab by n space, if the string is empty tabs won't be replaced* but I don't know it for sure.

## Check List

- [x] Others (Update, fix, translation, etc...)


