### PR TITLE
docs: move Deployment to a separate section

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -13,7 +13,8 @@ docs:
     data_files: data-files.html
     server: server.html
     generating: generating.html
-    deployment: deployment.html
+  deployment:
+    other_deployments: deployment.html
   customization:
     permalinks: permalinks.html
     themes: themes.html

--- a/source/docs/deployment.md
+++ b/source/docs/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Deployment
+title: Other Deployments
 ---
 
 Hexo provides a fast and easy deployment strategy. You only need one single command to deploy your site to your servers.

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -34,6 +34,7 @@ sidebar:
     server: Server
     generating: Generating
     deployment: Deployment
+    other_deployments: Other Deployments
     customization: Customization
     permalinks: Permalinks
     themes: Themes


### PR DESCRIPTION
I'm writing github, gitlab pages and netlify guides which I intend to put them under Deployment section.

Personally I feel travis and gitlab ci are easier to use than 'hexo deploy' and integrate better with github and gitlab respectively. Even https://github.com/hexojs/warehouse uses travis to publish. 'hexo deploy' is more suitable for other platforms that lacks CI (or at least easy-to-use one).

## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)

