### PR TITLE
fix(theme): load github button from jsdelivr

### DIFF
--- a/themes/navy/layout/partial/share.swig
+++ b/themes/navy/layout/partial/share.swig
@@ -5,6 +5,6 @@
 <!-- Twitter follow button -->
 <a href="https://twitter.com/hexojs" class="twitter-follow-button" data-show-count="true">Follow @hexojs</a>
 <!-- Github Button -->
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<script async defer src="https://cdn.jsdelivr.net/npm/github-buttons@2.2.10/dist/buttons.min.js"></script>
 <!-- Twitter share button -->
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)

Noticed it while running [WebPageTest](https://webpagetest.org) on hexo.io
I can verify it has the same hash as https://buttons.github.io/buttons.js (v2.2.10).