### PR TITLE
chore(netlify): disable js/css bundle & minify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,10 @@
   to = "/pt-br/"
   status = 302
   conditions = {Language = ["pt-br"]}
+
+[build.processing.css]
+  bundle = false
+  minify = false
+[build.processing.js]
+  bundle = false
+  minify = false


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

Netlify supports HTTP/2 which enables multiplexing, so bundling wouldn't benefit and maybe harder to cache.

hexo-uglify + hexo-clean-css replace the netlify's minify.