### PR TITLE
Update ZEIT Now deployment with script and button

### DIFF
--- a/source/docs/one-command-deployment.md
+++ b/source/docs/one-command-deployment.md
@@ -225,7 +225,7 @@ $ npm i -g now
 ```json
 {
   "scripts": {
-    "build: "hexo generate"
+    "build": "hexo generate"
   }
 }
 ```

--- a/source/docs/one-command-deployment.md
+++ b/source/docs/one-command-deployment.md
@@ -222,10 +222,10 @@ $ npm i -g now
 
 2. Add a build script to your `package.json` file:
 
-```
+```json
 {
   "scripts": {
-    "build: "hexo deploy"
+    "build: "hexo generate"
   }
 }
 ```
@@ -235,6 +235,10 @@ $ npm i -g now
 ```bash
 now
 ```
+
+Alternatively, you can click the deploy button below to create a new project:
+
+[![Deploy Now](https://zeit.co/button)](https://zeit.co/new/hexo)
 
 ## Other Methods
 


### PR DESCRIPTION
## Check List

- [x] Others (Update, fix, translation, etc...)

I think there was confusion between the `hexo deploy` and `hexo generate`.

It sounds like we want to use `hexo generate` instead to build the project as seen in this PR: https://github.com/hexojs/hexo-starter/pull/21

I also add a one-click deployment button which links to https://zeit.co/new/hexo

Button Documentation: https://zeit.co/docs/v2/advanced/deploy-button
