### PR TITLE
build: remove unneeded hexo-deployer-git

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,9 +15,6 @@ post_asset_folder: true
 per_page: 0
 
 theme: navy
-deploy:
-  type: git
-  repo: git@github.com:hexojs/hexojs.github.io.git
 
 highlight:
   enable: true

--- a/package.json
+++ b/package.json
@@ -7,14 +7,12 @@
   },
   "scripts": {
     "build": "hexo generate",
-    "eslint": "eslint .",
-    "deploy": "hexo deploy"
+    "eslint": "eslint ."
   },
   "dependencies": {
     "cheerio": "^0.22.0",
     "hexo": "github:hexojs/hexo",
     "hexo-clean-css": "^1.0.0",
-    "hexo-deployer-git": "^2.0.0",
     "hexo-filter-nofollow": "^2.0.2",
     "hexo-generator-archive": "^1.0.0",
     "hexo-generator-feed": "^2.0.0",


### PR DESCRIPTION

- [x] Others (Update, fix, translation, etc...)

A relic of the past [hexojs.github.io](https://github.com/hexojs/hexojs.github.io). It's not even necessary to use the config as example, as the [one-command deployment](https://hexo.io/docs/one-command-deployment) page already has the instruction.