### PR TITLE
fix(responsive): join stream read properly

### DIFF
--- a/scripts/responsive.js
+++ b/scripts/responsive.js
@@ -57,7 +57,7 @@ async function responsive() {
       assetPath.on('end', async() => {
         if (assetData.length) {
           try {
-            const result = assetData.join().replace(/<img (src|data-src)=['"](.*?)['"](.*?)>/gi, (imgTag, attr, value, alt) => {
+            const result = assetData.join('').replace(/<img (src|data-src)=['"](.*?)['"](.*?)>/gi, (imgTag, attr, value, alt) => {
               if (Object.prototype.hasOwnProperty.call(updatePng, value)) {
                 const jpg = updatePng[value].jpg;
 


### PR DESCRIPTION

- [x] Others (Update, fix, translation, etc...)

`assetData` may have more than one element (resulted from multiple chunks), so `Array.join('')` should be used to avoid separator, instead of the default comma separator.