### PR TITLE
fix: full_url_for helper not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "cheerio": "^0.22.0",
-    "hexo": "github:hexojs/hexo",
+    "hexo": "hexojs/hexo#79bdc9548752acfba89b26dec2c532c9346a1380",
     "hexo-clean-css": "^1.0.0",
     "hexo-filter-nofollow": "^2.0.2",
     "hexo-generator-archive": "^1.0.0",

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -47,6 +47,8 @@ hexo.extend.helper.register('doc_sidebar', function(className) {
   const self = this;
   const prefix = 'sidebar.' + type + '.';
 
+  if (typeof sidebar === 'undefined') return;
+
   for (let [title, menu] of Object.entries(sidebar)) {
     result += '<strong class="' + className + '-title">' + self.__(prefix + title) + '</strong>';
 


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

Emergency fix after #1139 as `full_url_for()` couldn't be found.

Netlify and Travis CI both don't have the latest commit when using `"hexojs/hexo"`

This PR force them to install the latest commit (https://github.com/hexojs/hexo/commit/79bdc9548752acfba89b26dec2c532c9346a1380)

Related issue: https://github.com/hexojs/site/pull/1102