### PR TITLE
fix(page_nav): remove duplicate 'Next' nav links

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -31,8 +31,6 @@ hexo.extend.helper.register('page_nav', function() {
   }
 
   if (index < keys.length - 1) {
-    result += '<a href="' + keys[index + 1] + '" class="article-footer-next" title="' + this.__(prefix + list[keys[index + 1]]) + '">'
-      + '<span>' + this.__('page.next') + '</span><i class="fa fa-chevron-right"></i></a>';
     result += `<a href="${keys[index + 1]}" class="article-footer-next" title="${this.__(prefix + list[keys[index + 1]])}"><span>${this.__('page.next')}</span><i class="fa fa-chevron-right"></i></a>`;
   }
 


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)
Another fix for https://github.com/hexojs/site/pull/1139

It's not very urgent because somehow the duplicated 'Next" is displayed on top of existing one, meaning it still display as one despite having two duplicate `<a>`.