### PR TITLE
chore: always use latest commit of hexo

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "cheerio": "^0.22.0",
-    "hexo": "hexojs/hexo#79bdc9548752acfba89b26dec2c532c9346a1380",
+    "hexo": "hexojs/hexo",
     "hexo-clean-css": "^1.0.0",
     "hexo-filter-nofollow": "^2.0.2",
     "hexo-generator-archive": "^1.0.0",


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

Now that it's possible for us to clear the netlify's npm cache, this workaround is not needed anymore.

Workaround was initially introduced in https://github.com/hexojs/site/pull/1173 to fix https://github.com/hexojs/site/issues/1170. npm cache issue was first discovered in https://github.com/hexojs/site/pull/1102.

Remember to clear netlify cache immediately after merging this PR. I believe to merge this before merging the rest of [v4-related PRs](https://github.com/hexojs/site/milestone/1).