### PR TITLE
fix(http-header): add x-frame and x-xss

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,9 @@
   to = "/pt-br/"
   status = 302
   conditions = {Language = ["pt-br"]}
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

I intend to harden HTTP security-related headers. I start with the easiest ones (least likely to cause breakage).

How to test:
1. Open deploy preview
2. Check the HTTP response header.

Ref: https://securityheaders.com/