### PR TITLE
build: use node 10 LTS and set prod env

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   command = "npm run build"
   publish = "/public"
+  environment = { NODE_VERSION = "10", NODE_ENV = "production" }
 
 [[redirects]]
   from = "/"


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

Netlify currently defaults to Node 8, this PR upgrades it to v10.
Set `production` environment to skip devDependency, eslint & imagemin are not relevant to netlify build.

ref: https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-and-javascript