### PR TITLE
site(http_header): add nosniff and feature-policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,3 +38,5 @@
   [headers.values]
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Feature-Policy = "accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; camera 'none'; display-capture 'none'; document-domain 'none'; encrypted-media 'none'; fullscreen 'self'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vibrate 'none'; wake-lock 'none'; webauthn 'none'"


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

[`nosniff`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) is to opt-out from [mime-type sniffing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#MIME_sniffing).

Feature-policy is mainly to prevent third-party resources to access device sensors, e.g. to mitigate possible [privacy risk](https://blog.lukaszolejnik.com/stealing-sensitive-browser-data-with-the-w3c-ambient-light-sensor-api/). This header is highly experimental, so some of the directives are not supported in certain browsers.

ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy