### PR TITLE
fix(index): theme link 404

### DIFF
--- a/themes/navy/layout/index.swig
+++ b/themes/navy/layout/index.swig
@@ -51,7 +51,7 @@
         <div class="theme-intro-container">
           <h2 class="theme-intro-title">{{ site.data.themes.length }} {{ __('menu.themes') }}</h2>
           <p class="theme-intro-text">{{ __('index.theme_intro') }}</p>
-          <a href="themes/" id="theme-link">{{ __('index.theme_link') }}</a>
+          <a href="/themes/" id="theme-link">{{ __('index.theme_link') }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)

Fix 404 theme link for other languages.

When at subdirectory of other languages (for example `https://hexo.io/zh-cn/`), `themes/` will turn into something like `/zh-cn/themes/` and causes 404.