### PR TITLE
docs: replace 'slug' term with 'filename'

### DIFF
--- a/source/docs/tag-plugins.md
+++ b/source/docs/tag-plugins.md
@@ -252,8 +252,8 @@ Inserts a responsive or specified size Vimeo video.
 Include links to other posts.
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag.
@@ -299,9 +299,9 @@ For instance:
 Include post assets.
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw

--- a/source/ko/docs/tag-plugins.md
+++ b/source/ko/docs/tag-plugins.md
@@ -218,8 +218,8 @@ Vimeo video를 포함시킬 수 있습니다.
 다른 포스트의 링크를 포함시킬 수 있습니다.
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag.
@@ -265,9 +265,9 @@ For instance:
 포스트의 asset을 포함시킬 수 있습니다.
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw

--- a/source/pt-br/docs/tag-plugins.md
+++ b/source/pt-br/docs/tag-plugins.md
@@ -221,8 +221,8 @@ Insere um vídeo do Vimeo.
 Incluir links para outras postagens.
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag.
@@ -268,9 +268,9 @@ For instance:
 Incluir assets de postagem.
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw

--- a/source/ru/docs/tag-plugins.md
+++ b/source/ru/docs/tag-plugins.md
@@ -218,8 +218,8 @@ content
 Содержит ссылку на другой пост.
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag.
@@ -265,9 +265,9 @@ For instance:
 Содержит содержимое материала.
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Сырцы

--- a/source/th/docs/tag-plugins.md
+++ b/source/th/docs/tag-plugins.md
@@ -221,8 +221,8 @@ content
 รวมลิงก์ของโพสต์อื่นๆเข้าไปใน  block:
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 เวลาใช้แท็กนี้ ข้อมูล permalink และ folder เช่น ภาษาและวันเดือนปี จะถูกละเลย
@@ -272,9 +272,9 @@ Post's title and custom text are escaped by default. You can use the `escape` op
 รวม post asset อยู่ใน block
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw

--- a/source/zh-cn/docs/tag-plugins.md
+++ b/source/zh-cn/docs/tag-plugins.md
@@ -250,8 +250,8 @@ content
 引用其他文章的链接。
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 在使用此标签时可以忽略文章文件所在的路径或者文章的永久链接信息、如语言、日期。
@@ -293,9 +293,9 @@ content
 引用文章的资源。
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw

--- a/source/zh-tw/docs/tag-plugins.md
+++ b/source/zh-tw/docs/tag-plugins.md
@@ -214,8 +214,8 @@ content
 引用其他文章的連結。
 
 ```
-{% post_path slug %}
-{% post_link slug [title] [escape] %}
+{% post_path filename %}
+{% post_link filename [title] [escape] %}
 ```
 
 You can ignore permalink and folder information, like languages and dates, when using this tag.
@@ -261,9 +261,9 @@ For instance:
 引用文章的資產。
 
 ```
-{% asset_path slug %}
-{% asset_img slug [title] %}
-{% asset_link slug [title] [escape] %}
+{% asset_path filename %}
+{% asset_img filename [title] %}
+{% asset_link filename [title] [escape] %}
 ```
 
 ## Raw


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

`filename` is more common, compared to `slug`.
<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
