### PR TITLE
docs(deploy): add a overview page

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -14,6 +14,7 @@ docs:
     server: server.html
     generating: generating.html
   deployment:
+    deployment: deployment.html
     github_pages: github-pages.html
     gitlab_pages: gitlab-pages.html
     one_command_deployment: one-command-deployment.html

--- a/source/docs/deployment.md
+++ b/source/docs/deployment.md
@@ -1,0 +1,47 @@
+---
+title: Deploy
+---
+
+As a static site generator, Hexo renders *static* websites. You can host your website on any server, CDN or your favorite development platform.
+
+## Platforms
+
+### GitHub Pages
+
+Deploy Hexo to GitHub Pages as a personal/project site and automate the whole process with Travis CI. [Read More](github-pages).
+
+### GitLab Pages
+
+With GitLab's built-in CI runner, you can easy to build your Hexo website and deploy to GitLab Pages service. [Read More](gitlab-pages).
+
+### Netlify
+
+Netlify provides free static site hosting service with CDN, CI/CD and Automated SSL. [Read More](one-command-deployment#Netlify).
+
+### ZEIT Now
+
+ZEIT Now is a severless cloud platform for websites and serverless APIs. [Read More](one-command-deployment#ZEIT-Now).
+
+### Heroku
+
+Heroku is a cloud platform that lets companies build, deliver, monitor and scale apps. [Read More](one-command-deployment#Heroku).
+
+### OpenShift
+
+OpenShift is an open source container application platform by Red Hat. [Read More](one-command-deployment#OpenShift)
+
+## Deployer Plugins
+
+Besides them, Hexo also provides many plugins that can help you to deploy your Hexo website. Just go to [Plugins List](/plugins) and type `deployer` in the search form and find out! Here are only a few of them:
+
+### Git
+
+Deploy your Hexo website to any git-supported platform with [`hexo-deployer-git`](one-command-deployment#Git).
+
+### Rsync
+
+Deploy your Hexo website using rsync with [`hexo-deployer-rsync`](one-command-deployment#Rsync).
+
+### FTP/SFTP
+
+Deploy your Hexo website to your server using FTP/SFTP with [`hexo-deployer-ftpsync`](one-command-deployment#FTPSync) or [`hexo-deployer-sftp`](one-command-deployment#SFTP).


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)

The original idea came from [here](https://gohugo.io/hosting-and-deployment/). This is a draft of adding a deployment overview page. Demo can be found at Netlify and pages will only be copied to other lang's directories after everyone is happy with the PR.
