### PR TITLE
fix: 'undefined' on about page (#1210)

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -45,7 +45,9 @@ hexo.extend.helper.register('doc_sidebar', function(className) {
   const self = this;
   const prefix = 'sidebar.' + type + '.';
 
-  if (typeof sidebar === 'undefined') return;
+  if (typeof sidebar === 'undefined') {
+    return '';
+  }
 
   for (let [title, menu] of Object.entries(sidebar)) {
     result += '<strong class="' + className + '-title">' + self.__(prefix + title) + '</strong>';


### PR DESCRIPTION
## Check List

- [x] Others (Update, fix, translation, etc...)

Fixed #1210 

## Note

This PR hide 'undefined', but the sidebar element exists. Please see the following. 

![2019-11-13 212349](https://user-images.githubusercontent.com/11273093/68763492-edd26280-065b-11ea-97d8-71e5cf44df46.jpg)

We have to add a conditional operator to [here](https://github.com/hexojs/site/blob/22784f5c06cb48eea3d4e0620b5b27725a9b7e74/themes/navy/layout/page.swig#L32), if we do not want render sidebar element when it does not exists.