### PR TITLE
build: remove trailing 'index.html'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ code_dir: downloads/code
 new_post_name: :year-:month-:day-:title.md # File name of new posts
 post_asset_folder: true
 per_page: 0
+pretty_urls:
+  trailing_index: false
 
 theme: navy
 


### PR DESCRIPTION
- [x] Others (Update, fix, translation, etc...)

Noticed when testing https://github.com/hexojs/site/pull/1225. Netlify prettify the urls by default, so this config makes it more consistent.

the sitemap still have url like `hexo.io/docs/configuration.html`, where it should be `hexo.io/docs/configuration/`. `pretty_urls.trailing_html` option is not available yet.