### PR TITLE
doc: update swig link

### DIFF
--- a/source/docs/themes.md
+++ b/source/docs/themes.md
@@ -77,7 +77,7 @@ When you have finished building your theme, you can publish it to the [theme lis
 6. Create a pull request and describe the change.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug

--- a/source/ko/docs/themes.md
+++ b/source/ko/docs/themes.md
@@ -74,7 +74,7 @@ Hexo는 모든 렌더링 가능한 파일들을 처리한 후 `public` 폴더에
 6. 변경사항에 대한 설명을 포함하여 Pull request를 생성합니다.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [hexojs/site]: https://github.com/hexojs/site

--- a/source/pt-br/docs/themes.md
+++ b/source/pt-br/docs/themes.md
@@ -77,7 +77,7 @@ Quando você terminar de criar seu tema, você pode publicá-lo na [lista de tem
 6. Crie um pull request e descreva as mudanças.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug

--- a/source/ru/docs/themes.md
+++ b/source/ru/docs/themes.md
@@ -75,7 +75,7 @@ Hexo будет сохранять все обработанные файлы в
 6. Создайте запрос на слияние с описанием изменений.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [hexojs/site]: https://github.com/hexojs/site

--- a/source/th/docs/themes.md
+++ b/source/th/docs/themes.md
@@ -85,7 +85,7 @@ hexo จะจัดการและบันทึกไฟล์ทั้ง
 6. Create a pull request and describe the change.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug

--- a/source/zh-cn/docs/themes.md
+++ b/source/zh-cn/docs/themes.md
@@ -73,7 +73,7 @@ layout.swig  - 使用 Swig
 6. 建立一个新的合并申请（pull request）并描述改动。
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [hexojs/site]: https://github.com/hexojs/site

--- a/source/zh-tw/docs/themes.md
+++ b/source/zh-tw/docs/themes.md
@@ -74,7 +74,7 @@ Swig: layout.swig
 6. 建立一個新的合併申請（pull request）。
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/paularmstrong/swig
+[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [hexojs/site]: https://github.com/hexojs/site


### PR DESCRIPTION
https://github.com/paularmstrong/swig deprecated since 2016, https://github.com/node-swig/swig-templates seems to be the reborn project