### PR TITLE
docs(img-tag): title text should be quoted

### DIFF
--- a/source/docs/tag-plugins.md
+++ b/source/docs/tag-plugins.md
@@ -190,7 +190,7 @@ To embed an iframe:
 Inserts an image with specified size.
 
 ```
-{% img [class names] /path/to/image [width] [height] "title text 'alt text'" %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link

--- a/source/ko/docs/tag-plugins.md
+++ b/source/ko/docs/tag-plugins.md
@@ -188,7 +188,7 @@ iframe을 포함시킬 수 있습니다.
 이미지의 사이즈를 지정하여 포함시킬 수 있습니다.
 
 ```
-{% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link

--- a/source/pt-br/docs/tag-plugins.md
+++ b/source/pt-br/docs/tag-plugins.md
@@ -191,7 +191,7 @@ Para incorporar um iframe:
 Insere uma imagem com tamanho especificado.
 
 ```
-{% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link

--- a/source/ru/docs/tag-plugins.md
+++ b/source/ru/docs/tag-plugins.md
@@ -188,7 +188,7 @@ content
 Вставляет картинку с заданными размерами.
 
 ```
-{% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Ссылка

--- a/source/th/docs/tag-plugins.md
+++ b/source/th/docs/tag-plugins.md
@@ -191,7 +191,7 @@ content
 เสียบรูปภาพที่มีขนาดเฉพาะเข้า:
 
 ```
-{% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link

--- a/source/zh-cn/docs/tag-plugins.md
+++ b/source/zh-cn/docs/tag-plugins.md
@@ -188,7 +188,7 @@ content
 在文章中插入指定大小的图片。
 
 ```
-{% img [class names] /path/to/image [width] [height] "title text 'alt text'" %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link

--- a/source/zh-tw/docs/tag-plugins.md
+++ b/source/zh-tw/docs/tag-plugins.md
@@ -184,7 +184,7 @@ content
 在文章中插入指定大小的圖片。
 
 ```
-{% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
+{% img [class names] /path/to/image [width] [height] '"title text" "alt text"' %}
 ```
 
 ## Link


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)

The current example:

`{% img class-name /path/to/image 100 100 "title text 'alt text'" %}`

``` html
<img src="/path/to/image" class="class-name" width="100" height="100" title="title text " alt="alt text">
```

Notice the trailing space in the title attribute.

The correct usage is to quote both title and alt, then quote both of them:

`{% img class-name /path/to/image 100 100 '"title text" "alt text"' %}`

``` html
<img src="/path/to/image" class="class-name" width="100" height="100" title="title text" alt="alt text">
```

`"'title text' 'alt text'"` also works.

Closes https://github.com/hexojs/hexo/issues/1277