### PR TITLE
categories and tags are array of string

### DIFF
--- a/source/docs/variables.md
+++ b/source/docs/variables.md
@@ -23,8 +23,8 @@ Variable | Description | Type
 --- | --- | ---
 `site.posts` | All posts | `array` of `post` objects
 `site.pages` | All pages | `array` of `page` objects
-`site.categories` | All categories | `array` of ???
-`site.tags` | All tags | `array` of ???
+`site.categories` | All categories | `array` of `string`
+`site.tags` | All tags | `array` of `string`
 
 ### Page Variables
 
@@ -55,8 +55,8 @@ Variable | Description | Type
 Variable | Description | Type
 --- | --- | ---
 `page.published` | True if the post is not a draft | `boolean`
-`page.categories` | All categories of the post | `array` of ???
-`page.tags` | All tags of the post | `array` of ???
+`page.categories` | All categories of the post | `array` of `string`
+`page.tags` | All tags of the post | `array` of `string`
 
 **Home (`index`)**
 

--- a/source/pt-br/docs/variables.md
+++ b/source/pt-br/docs/variables.md
@@ -23,8 +23,8 @@ Variável | Descrição | Tipo
 --- | --- | ---
 `site.posts` | Todos as postagens | `array` de objetos `post`
 `site.pages` | Todas as páginas | `array` de objetos `page`
-`site.categories` | Todas as categorias | `array` de ???
-`site.tags` | Todas as tags | `array` de ???
+`site.categories` | Todas as categorias | `array` de `string`
+`site.tags` | Todas as tags | `array` de `string`
 
 ### Variáveis da Página
 
@@ -55,8 +55,8 @@ Variável | Descrição | Tipo
 Variável | Descrição | Tipo
 --- | --- | ---
 `page.published` | Verdadeiro se a postagem não for um rascunho | `boolean`
-`page.categories` | Todas as categorias da postagem | `array` de ???
-`page.tags` | Todas as tags da postagem | `array` de ???
+`page.categories` | Todas as categorias da postagem | `array` de `string`
+`page.tags` | Todas as tags da postagem | `array` de `string`
 
 **Home (`index`)**
 

--- a/source/th/docs/variables.md
+++ b/source/th/docs/variables.md
@@ -23,8 +23,8 @@ Variable | Description | Type
 --- | --- | ---
 `site.posts` | All posts | `array` of `post` objects
 `site.pages` | All pages | `array` of `page` objects
-`site.categories` | All categories | `array` of ???
-`site.tags` | All tags | `array` of ???
+`site.categories` | All categories | `array` of `string`
+`site.tags` | All tags | `array` of `string`
 
 ### Page Variables
 
@@ -55,8 +55,8 @@ Variable | Description | Type
 Variable | Description | Type
 --- | --- | ---
 `page.published` | True if the post is not a draft | `boolean`
-`page.categories` | All categories of the post | `array` of ???
-`page.tags` | All tags of the post | `array` of ???
+`page.categories` | All categories of the post | `array` of `string`
+`page.tags` | All tags of the post | `array` of `string`
 
 **หน้าหลัก (`index`)**
 


### PR DESCRIPTION
I can't complete the documentation for other languages where `???` are rendered with a different charset.

## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
    - Languages:
    - [x] `en` English
    - [ ] `ko` Korean
    - [x] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [x] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese

Please I want to join hexo org.
