### PR TITLE
Update plugins.yml, add hexo-github-include

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -2511,3 +2511,12 @@
     - steam
     - game
     - embed
+- name: hexo-github-include
+  description: Include static listings of files stored on GitHub and convert them to markdown.
+  link: https://github.com/zbicin/hexo-github-include
+  tags:
+    - tag
+    - markdown
+    - github
+    - code
+    - snippet


### PR DESCRIPTION
This adds a `hexo-github-include` plugin to the list.

## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [x] I want to publish my plugin on Hexo official website.
    - [x] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [x] `name` is unique.
    - [x] `link` URL is correct.
- [ ] Others (Update, fix, translation, etc...)
    - Languages:
    - [ ] `en` English
    - [ ] `ko` Korean
    - [ ] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [ ] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
