### PR TITLE
chore(news): Hexo 4.2.1 & official plugin hexo-fs 2.0.1 & hexo-util 1…

### DIFF
--- a/source/_posts/2020-05-14-hexo-4-2-1-hexo-fs-2-0-1-hexo-util-1-9-1.md
+++ b/source/_posts/2020-05-14-hexo-4-2-1-hexo-fs-2-0-1-hexo-util-1-9-1.md
@@ -1,0 +1,36 @@
+---
+title: Hexo 4.2.1 & official plugin hexo-fs 2.0.1 & hexo-util 1.9.1 released
+---
+
+## Hexo 4.2.1
+
+Before `4.2.0`, Hexo does not work with Node 14. This is a patch release for support Node 14.
+
+### Fix
+
+- chore: incompatible with Node 14 [#4285]
+    - This release includes [hexo-util 1.9.1](https://github.com/hexojs/hexo-util/releases/tag/1.9.1) and [hexo-fs 2.0.1](https://github.com/hexojs/hexo-fs/releases/tag/2.0.1)
+
+[#4285]: https://github.com/hexojs/hexo/pull/4285
+
+---
+
+## hexo-util 1.9.1
+
+### Fix
+
+- Fix [`CacheStream()`](https://github.com/hexojs/hexo-util#cachestream) compatibility issue with Node 14 [@curbengh](https://github.com/curbengh) [#205]
+    + This fix is backport from [hexo-util 2.0.0](https://github.com/hexojs/hexo-util/releases/tag/2.0.0)
+
+[#205]: https://github.com/hexojs/hexo-util/pull/205
+
+---
+
+## hexo-fs 2.0.1
+
+### Fix
+
+- fix compatibility issue with Node.js 14 in writeFile() and copyFile() @SukkaW (#70)
+    + This fix is backport from [hexo-fs 3.0.0](https://github.com/hexojs/hexo-fs/releases/tag/3.0.0)
+
+[#70]: https://github.com/hexojs/hexo-fs/pull/70


### PR DESCRIPTION
….9.1 released

## What is this ?

Release news of 

* https://github.com/hexojs/hexo/releases/tag/4.2.1
* https://github.com/hexojs/hexo-util/releases/tag/1.9.1
* https://github.com/hexojs/hexo-fs/releases/tag/2.0.1


Refs: https://github.com/hexojs/hexo/pull/4285

## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)
    - Languages:
    - [ ] `en` English
    - [ ] `ko` Korean
    - [ ] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [ ] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
