### PR TITLE
fix(css): set colour of `<code>` with link

### DIFF
--- a/themes/navy/source/css/_partial/page.styl
+++ b/themes/navy/source/css/_partial/page.styl
@@ -141,6 +141,8 @@ note-warn = hsl(0, 100%, 50%)
       &:after
         content: " (" attr(href) ")"
         font-size: 80%
+    code
+      color: color-link
   strong
     font-weight: bold
   em


### PR DESCRIPTION
I often link to an api method and plugin using a backtick, but currently the links use `<code>` colour, so reader would only discern that it's a link when hover on it (which displays the underline).

````
[`foo`](/bar/baz)
````

A recent post is an example (https://hexo.io/news/2020/08/22/hexo-5-1_marked-3-1_math-4_util-2-4/), look for the following line.

````
* also available via [`codeblock`](/docs/tag-plugins#Code-Block) and [`include_code`](/docs/tag-plugins#Include-Code) tag plugins.
````

## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [ ] Others (Update, fix, translation, etc...)
    - Languages:
    - [ ] `en` English
    - [ ] `ko` Korean
    - [ ] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [ ] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
