### PR TITLE
Remove docs about plugins option

### DIFF
--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -218,20 +218,7 @@ Sometimes when running the command `$ hexo generate` it returns an error:
 FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
 Template render error: (unknown path)
 ```
-It means that there are some unrecognizable words in your file, e.g. invisible zero width characters. There are two possibilities One is your new page/post, and the other one is `_config.yml`.
-In `_config.yml`, don't forget add whitespace before a list in hash. There is the wiki page about [YAML](https://en.wikipedia.org/wiki/YAML).
-The error one:
-```
-plugins:
-- hexo-generator-feed
-- hexo-generator-sitemap
-```
-The correct one:
-```
-plugins:
-  - hexo-generator-feed
-  - hexo-generator-sitemap
-```
+One possible reason is that there are some unrecognizable words in your file, e.g. invisible zero width characters.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/pt-br/docs/troubleshooting.md
+++ b/source/pt-br/docs/troubleshooting.md
@@ -204,21 +204,7 @@ Este é [um problema no BashOnWindows conhecido](https://github.com/Microsoft/Ba
 FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
 Template render error: (unknown path)
 ```
-Isso significa que existem algumas palavras irreconhecíveis no seu arquivo. Existem duas possibilidades, uma é seu novo page/post, a outra é o `_config.yml`.
-Em `_config.yml`, não esqueça de adicionar espaços em branco antes de uma lista no hash. Existe uma página wiki sobre [YAML](https://en.wikipedia.org/wiki/YAML).
-
-Forma errada:
-```
-plugins:
-- hexo-generator-feed
-- hexo-generator-sitemap
-```
-Forma correta:
-```
-plugins:
-  - hexo-generator-feed
-  - hexo-generator-sitemap
-```
+One possible reason is that there are some unrecognizable words in your file, e.g. invisible zero width characters.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/th/docs/troubleshooting.md
+++ b/source/th/docs/troubleshooting.md
@@ -247,22 +247,7 @@ $ hexo server -s
 FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
 Template render error: (unknown path)
 ```
-ถ้าเป็นอย่างนี้ หมายความว่ามีคำบางคำท่ีอ่านไม่ออกในไฟล์ เหตุผลท่ีก่อให้เกิดเรื่องนี้คือสองอย่าง อย่างแรกคือ page/post ใหม่ของคุณ อย่างท่ีสองคือ `_config.yml`  ในไฟล์ `_config.yml` อย่่าลืมเพิ่ม whitespace ก่อนไฟล์ท่ีเป็น hash ท่ีนี่มีเพจวิกิเกี่ยวกับ [YAML](https://en.wikipedia.org/wiki/YAML)
-
-
-
-ตัวท่ีผิดพลาด:
-```
-plugins:
-- hexo-generator-feed
-- hexo-generator-sitemap
-```
-ตัวท่ีถูกต้อง:
-```
-plugins:
-  - hexo-generator-feed
-  - hexo-generator-sitemap
-```
+One possible reason is that there are some unrecognizable words in your file, e.g. invisible zero width characters.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/zh-cn/docs/troubleshooting.md
+++ b/source/zh-cn/docs/troubleshooting.md
@@ -210,25 +210,7 @@ FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/do
 Template render error: (unknown path)
 ```
 
-这表明你的文件中存在一些不可被识别的字符，比如不可见的零宽度字符。有可能你的新文章存在这个问题，或者你在修改配置文件时导致了这个错误。
-
-检查你的 `_config.yml` 文件中是否漏掉了列表前的空格。你可以查阅 Wikipedia 中 [YAML](https://zh.wikipedia.org/wiki/YAML) 相关页面来学习 YAML 语法。
-
-这个是错误的：
-
-```yaml
-plugins:
-- hexo-generator-feed
-- hexo-generator-sitemap
-```
-
-正确的应该是这样：
-
-```yaml
-plugins:
-  - hexo-generator-feed
-  - hexo-generator-sitemap
-```
+一种可能的原因是你的文件中存在一些不可被识别的字符，比如不可见的零宽度字符。
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/zh-tw/docs/troubleshooting.md
+++ b/source/zh-tw/docs/troubleshooting.md
@@ -162,20 +162,7 @@ Sometimes when running the command `$ hexo generate` it returns an error:
 FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
 Template render error: (unknown path)
 ```
-It means that there are some unrecognizable words in your file, e.g. invisible zero width characters. There are two possibilities One is your new page/post, and the other one is `_config.yml`.
-In `_config.yml`, don't forget add whitespace before a list in hash. There is the wiki page about [YAML](https://en.wikipedia.org/wiki/YAML).
-The error one:
-```
-plugins:
-- hexo-generator-feed
-- hexo-generator-sitemap
-```
-The correct one:
-```
-plugins:
-  - hexo-generator-feed
-  - hexo-generator-sitemap
-```
+One possible reason is that there are some unrecognizable words in your file, e.g. invisible zero width characters.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
    - Languages:
    - [x] `en` English
    - [x] `ko` Korean
    - [x] `pt-br` Brazilian Portuguese
    - [x] `ru` Russian
    - [x] `th` Thai
    - [x] `zh-cn` simplified Chinese
    - [x] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->

`plugins` option removed in https://github.com/hexojs/hexo/pull/4475
See also https://github.com/hexojs/site/pull/459