### PR TITLE
Update preview link for theme Cupertino

### DIFF
--- a/source/_data/themes.yml
+++ b/source/_data/themes.yml
@@ -3397,7 +3397,7 @@
 - name: Cupertino
   description: The Hexo Blog Theme Cupertino.
   link: https://github.com/MrWillCom/hexo-theme-cupertino
-  preview: https://mrwillcom.github.io
+  preview: https://mrwillcom.now.sh
   tags:
     - responsive
     - dark/light


### PR DESCRIPTION
For some reason, https://mrwillcom.now.sh/ becomes the official website of theme Cupertino.

Already checked the check list.

Thanks!
