### PR TITLE
chroe(news): release news of hexo-util 2.5.0

### DIFF
--- a/source/_posts/2021-05-05-hexo-util-2-5-0-released.md
+++ b/source/_posts/2021-05-05-hexo-util-2-5-0-released.md
@@ -1,0 +1,35 @@
+---
+title: hexo-util 2.5.0 released
+---
+
+
+## hexo-util 2.5.0
+
+> [v2.5.0 Release](https://github.com/hexojs/hexo-util/releases/tag/2.5.0)
+
+### Refactors
+
+- refactor(strip_html): remove striptags deps [@SukkaW] [#232]
+
+### Dependencies
+
+- Update dependency highlight.js [@stevenjoezhang] [#246]
+- Upgrade to GitHub-native Dependabot @dependabot-preview [#248]
+- chore(deps-dev): bump html-entities from 1.4.0 to 2.1.1 @dependabot-preview [#244]
+- chore(deps): bump htmlparser2 from 4.1.0 to 6.0.0 @dependabot-preview [#236]
+
+### Misc
+
+- Migrate to GitHub Actions [@stevenjoezhang] [#247]
+- Fix test cases [@stevenjoezhang] [#237]
+
+[@SukkaW]: https://github.com/SukkaW
+[@stevenjoezhang]: https://github.com/stevenjoezhang
+
+[#232]: https://github.com/hexojs/hexo-util/pull/232
+[#246]: https://github.com/hexojs/hexo-util/pull/246
+[#248]: https://github.com/hexojs/hexo-util/pull/248
+[#244]: https://github.com/hexojs/hexo-util/pull/244
+[#236]: https://github.com/hexojs/hexo-util/pull/236
+[#247]: https://github.com/hexojs/hexo-util/pull/247
+[#237]: https://github.com/hexojs/hexo-util/pull/237


### PR DESCRIPTION
## Check List

Add release news of [hexo-util 2.5.0](https://github.com/hexojs/hexo-util/releases/tag/2.5.0)

> https://github.com/hexojs/hexo-util/pull/249

- [ ] I want to publish my theme on Hexo official website.
    - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
    - [ ] `preview` URL is correct.
    - [ ] `preview` URL web site is rendered correctly.
    - [ ] Add a screenshot to `source/themes/screenshots`.
    - [ ] Screenshot filename is same as value of `name`.
    - [ ] Screenshot size is `800 * 500`.
    - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
    - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
    - [ ] `name` is unique.
    - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
    - Languages:
    - [x] `en` English
    - [ ] `ko` Korean
    - [ ] `pt-br` Brazilian Portuguese
    - [ ] `ru` Russian
    - [ ] `th` Thai
    - [ ] `zh-cn` simplified Chinese
    - [ ] `zh-tw` traditional Chinese