### PR TITLE
docs: fix privacy-enhanced YouTube video embed

### DIFF
--- a/source/ko/docs/tag-plugins.md
+++ b/source/ko/docs/tag-plugins.md
@@ -238,7 +238,7 @@ YouTube video를 포함시킬 수 있습니다.
 YouTube's cookie is not used in this mode.
 
 ```
-{% youtube lJIrF4YjHfQ false %}
+{% youtube lJIrF4YjHfQ 'video' false %}
 {% youtube PL9hW1uS6HUfscJ9DHkOSoOX45MjXduUxo 'playlist' false %}
 ```
 


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**


- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English

## Explanation

The YouTube embed plugin expects a type as the second parameter:

https://github.com/hexojs/hexo/blob/fc2979a43e2c04de045625de752d7674daa4db15/lib/plugins/tag/youtube.js#L12

If you don't provide a type but a boolean, then the plugin tries to render a playlist and fails with a plain video embed. That's why `{% youtube lJIrF4YjHfQ false %}` cannot be used as a shortcut to create privacy-enhanced embeds. It must be `{% youtube lJIrF4YjHfQ 'video' false %}`.