### PR TITLE
gitlab-ci node version upgrade

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "npm run build"
   publish = "/public"
-  environment = { NODE_VERSION = "10", NODE_ENV = "production" }
+  environment = { NODE_VERSION = "14", NODE_ENV = "production" }
 
 [[redirects]]
   from = "/"

--- a/source/docs/gitlab-pages.md
+++ b/source/docs/gitlab-pages.md
@@ -8,7 +8,7 @@ title: GitLab Pages
 4. Add `.gitlab-ci.yml` file to your repo (alongside _config.yml & package.json) with the following content:
 
 ``` yml
-image: node:10-alpine # use nodejs v10 LTS
+image: node:14-alpine # use nodejs v14 LTS
 cache:
   paths:
     - node_modules/


### PR DESCRIPTION
As said on the doc page itself: In .gitlab-ci.yml file, the node version needs to be updated to Nodejs version > 12.0.0, otherwise the pipeline will fail with error TypeError: line.matchAll is not a function