### PR TITLE
docs(open_graph): add some description

### DIFF
--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -870,6 +870,10 @@ Option | Description | Default
 `type` | Page type (`og:type`) | blog
 `url` | Page URL (`og:url`) | `url`
 `image` | Page images (`og:image`) | All images in the content
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | Site name (`og:site_name`) | `config.title`
 `description` | Page description (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/ko/docs/helpers.md
+++ b/source/ko/docs/helpers.md
@@ -757,6 +757,10 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `type` | 페이지 형태 (`og:type`) | blog
 `url` | 페이지 URL (`og:url`) | `url`
 `image` | 페이지 커버 (`og:image`) | All images in the content
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | 사이트 이름 (`og:site_name`) | `config.title`
 `description` | 페이지 설명 (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/pt-br/docs/helpers.md
+++ b/source/pt-br/docs/helpers.md
@@ -762,6 +762,10 @@ Opção | Descrição | Padrão
 `type` | Tipo de página (`og:type`) | blog
 `url` | URL da página (`og:url`) | `url`
 `image` | Capa da página (`og:image`) | All images in the content
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | Nome do site (`og:site_name`) | `config.title`
 `description`| Descrição da página (`og:description`) | Trecho da página ou os 200 primeiros caracteres do conteúdo
 `twitter_card` | Tipo de Twitter card (`twitter:card`) | summary

--- a/source/ru/docs/helpers.md
+++ b/source/ru/docs/helpers.md
@@ -755,6 +755,10 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `type` | Тип страницы (`og:type`) | blog
 `url` | URL-адрес страницы (`og:url`) | `url`
 `image` | Обложка страницы (`og:image`) | All images in the content
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | Имя сайта (`og:site_name`) | `config.title`
 `description` | Описание страницы (`og:description`) | Отрывок страницы или первые 200 символов содержимого
 `twitter_card` | Карточка Twitter (`twitter:card`) | Краткое изложение

--- a/source/th/docs/helpers.md
+++ b/source/th/docs/helpers.md
@@ -809,6 +809,10 @@ Option | Description | Default
 `type` | Page type (`og:type`) | blog
 `url` | Page URL (`og:url`) | `url`
 `image` | Page images (`og:image`) | All images in the content
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | Site name (`og:site_name`) | `config.title`
 `description` | Page description (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/zh-cn/docs/helpers.md
+++ b/source/zh-cn/docs/helpers.md
@@ -853,6 +853,10 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `type` | 页面类型 (`og:type`) | blog
 `url` | 页面网址 (`og:url`) | `url`
 `image` | 页面图片 (`og:image`) | 内容中的图片
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | 网站名称 (`og:site_name`) | `config.title`
 `description` | 页面描述 (`og:description`) | 内容摘要或前 200 字
 `twitter_card` | Twitter 卡片类型 (`twitter:card`) | summary

--- a/source/zh-tw/docs/helpers.md
+++ b/source/zh-tw/docs/helpers.md
@@ -745,6 +745,10 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `type` | 頁面類型 (`og:type`) | blog
 `url` | 頁面網址 (`og:url`) | `url`
 `image` | 頁面圖片 (`og:image`) | 內容中的圖片
+`author` | Article author (`og:article:author`) | `config.author`
+`date` | Article published time (`og:article:published_time`) | Page published time
+`updated` | Article modified time (`og:article:modified_time`) | Page modified time
+`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
 `site_name` | 網站名稱 (`og:site_name`) | `config.title`
 `description` | 頁面描述 (`og:description`) | 內容摘要或前 200 字
 `twitter_card` | Twitter 卡片類型 (`twitter:card`) | summary


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [ ] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [ ] `ko` Korean
  - [ ] `pt-br` Brazilian Portuguese
  - [ ] `ru` Russian
  - [ ] `th` Thai
  - [ ] `zh-cn` simplified Chinese
  - [ ] `zh-tw` traditional Chinese

Add some description: `author` `date` `updated` `language` 

![image](https://user-images.githubusercontent.com/15902347/141229399-417ce8bc-db6b-4654-b4e0-67f9e0eae378.png)

https://github.com/hexojs/hexo/issues/4814 If the theme has a custom author config, you need to modify the Open Graph options as well

example:
```js
open_graph({author: config.author.nick})
```
