### PR TITLE
news: hexo-renderer-ejs 2.0.0, hexo-generator-sitemap 2.2.0 released

### DIFF
--- a/source/_posts/2021-11-26-hexo-renderer-ejs-2-0-0-and-hexo-generator-sitemap-2-2-0-released.md
+++ b/source/_posts/2021-11-26-hexo-renderer-ejs-2-0-0-and-hexo-generator-sitemap-2-2-0-released.md
@@ -30,6 +30,8 @@ title: Official plugins hexo-renderer-ejs 2.0.0, hexo-generator-sitemap 2.2.0 re
 
 ## hexo-renderer-ejs 2.2.0
 
+> [Release 2.2.0](https://github.com/hexojs/hexo-generator-sitemap/releases/tag/2.2.0)
+
 ### Fixes
 
 * Provide a more reasonable default value for sitemap [#117](https://github.com/hexojs/hexo-generator-sitemap/pull/117) [@wdhongtw]

--- a/source/_posts/2021-11-26-hexo-renderer-ejs-2-0-0-and-hexo-generator-sitemap-2-2-0-released.md
+++ b/source/_posts/2021-11-26-hexo-renderer-ejs-2-0-0-and-hexo-generator-sitemap-2-2-0-released.md
@@ -1,0 +1,53 @@
+---
+title: Official plugins hexo-renderer-ejs 2.0.0, hexo-generator-sitemap 2.2.0 released
+---
+
+
+## hexo-renderer-ejs 2.0.0
+
+> [Release 2.0.0](https://github.com/hexojs/hexo-renderer-ejs/releases/tag/2.0.0)
+
+### Breaking Changes
+
+* Drop Node.js 10.x [#46](https://github.com/hexojs/hexo-renderer-ejs/pull/46) [@tomap]
+
+### Test
+
+* update to new include syntax [#27](https://github.com/hexojs/hexo-renderer-ejs/pull/27) [@SukkaW]
+
+### Dependencies
+
+* bump mocha from 6.2.3 to 9.1.0 [#36]((https://github.com/hexojs/hexo-renderer-ejs/pull/36), [#44](https://github.com/hexojs/hexo-renderer-ejs/pull/44)
+* Upgrade to GitHub-native Dependabot [#39](https://github.com/hexojs/hexo-renderer-ejs/pull/39)
+* bump mocha from 7.2.0 to 8.0.1 [#38](https://github.com/hexojs/hexo-renderer-ejs/pull/38)
+* bump eslint from 6.8.0 to 8.1.0 [#37](https://github.com/hexojs/hexo-renderer-ejs/pull/37), [#49](https://github.com/hexojs/hexo-renderer-ejs/pull/49)
+* bump hexo-fs from 2.0.0 to 3.0.1 [#35](https://github.com/hexojs/hexo-renderer-ejs/pull/35)
+* bump nyc from 14.1.1 to 15.0.0 [#29](https://github.com/hexojs/hexo-renderer-ejs/pull/29)
+* bump eslint-config-hexo from 3.0.0 to 4.0.0 [#28](https://github.com/hexojs/hexo-renderer-ejs/pull/28)
+* bump ejs from 2.7.4 to 3.0.1 [#26](https://github.com/hexojs/hexo-renderer-ejs/pull/26)
+
+---
+
+## hexo-renderer-ejs 2.2.0
+
+### Fixes
+
+* Provide a more reasonable default value for sitemap [#117](https://github.com/hexojs/hexo-generator-sitemap/pull/117) [@wdhongtw]
+
+### Dependencies
+
+* bump camaro from 5.0.3 to 6.1.0 [#128](https://github.com/hexojs/hexo-generator-sitemap/pull/128)
+* bump mocha from 8.4.0 to 9.1.2 [#125](https://github.com/hexojs/hexo-generator-sitemap/pull/125)
+* bump eslint from 7.32.0 to 8.0.0 [#127](https://github.com/hexojs/hexo-generator-sitemap/pull/127)
+
+## Misc
+
+* Update dependabot.yml [dde41e96] [@tomap]
+* Upgrade to GitHub-native Dependabot [#115](https://github.com/hexojs/hexo-generator-sitemap/pull/115)
+* migrate Travis to GitHubAction [#112](https://github.com/hexojs/hexo-generator-sitemap/pull/112) [@yoshinorin]
+
+
+[@wdhongtw]: https://github.com/wdhongtw
+[@SukkaW]: https://github.com/SukkaW
+[@tomap]: https://github.com/tomap
+[@yoshinorin]: https://github.com/yoshinorin


### PR DESCRIPTION
## What is this?

Release news of [hexo-generator-sitemap 2.2.0](https://github.com/hexojs/hexo-generator-sitemap/releases/tag/2.2.0) and [hexo-renderer-ejs 2.0.0](https://github.com/hexojs/hexo-renderer-ejs/releases/tag/2.0.0)

## Check List

- [ ] I want to publish my theme on Hexo official website.
  - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
  - [ ] `name` is unique.
  - [ ] `link` URL is correct.
  - [ ] `preview` URL is correct.
  - [ ] `preview` URL web site is rendered correctly.
  - [ ] Add a screenshot to `source/themes/screenshots`.
  - [ ] Screenshot filename is same as value of `name`.
  - [ ] Screenshot size is `800 * 500`.
  - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
  - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
  - [ ] `name` is unique.
  - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [ ] `en` English
  - [ ] `ko` Korean
  - [ ] `pt-br` Brazilian Portuguese
  - [ ] `ru` Russian
  - [ ] `th` Thai
  - [ ] `zh-cn` simplified Chinese
  - [ ] `zh-tw` traditional Chinese


