### PR TITLE
Updating Node.js version in `pages.yml` example

### DIFF
--- a/source/docs/github-pages.md
+++ b/source/docs/github-pages.md
@@ -30,7 +30,8 @@ In this tutorial, we use [GitHub Actions](https://docs.github.com/en/actions) to
   $ git push origin source
   ```
 
-4. Add `.github/workflows/pages.yml` file to your repo with the following content:
+4. Check what version of Node.js you are using on your local machine with `node --version`. Make a note of the major version (e.g., `v16.x`)
+5. Create `.github/workflows/pages.yml` in your repo with the following contents (substituting `v16.x` for whatever major version of Node.js you noted in the previous step):
 
 ```yml .github/workflows/pages.yml
 name: Pages
@@ -45,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Cache NPM dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Node.js v12 ships with npm v6, which uses version 1 of `package-lock.json`. Node.js v15+ ships with npm v7+, which currently uses version 2 of this file. If user has a version 2 `package-lock.json` in their repo, npm v6 may have trouble reading it, so the `Pages` workflow may fail. This should be avoided by guiding the user to use the same version of Node.js that they work with locally.

I left a [comment on the page](http://disq.us/p/2lbsr4c) with this detail, and also made a [blog post](https://murchu27.github.io/2021/12/13/Deploying-your-Hexo-blog-on-GitHub-Pages/).

## Check List

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [ ] `ko` Korean
  - [ ] `pt-br` Brazilian Portuguese
  - [ ] `ru` Russian
  - [ ] `th` Thai
  - [ ] `zh-cn` simplified Chinese
  - [ ] `zh-tw` traditional Chinese