### PR TITLE
chore(docs): change the description of the default renderer from Swig to Nunjucks

### DIFF
--- a/source/api/posts.md
+++ b/source/api/posts.md
@@ -58,4 +58,5 @@ The data must contain the `content` attribute. If not, Hexo will try to read the
 - Render with [Nunjucks]
 - Execute `after_post_render` filters
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
+

--- a/source/api/tag.md
+++ b/source/api/tag.md
@@ -142,5 +142,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/docs/themes.md
+++ b/source/docs/themes.md
@@ -25,11 +25,11 @@ Language folder. See [internationalization (i18n)](internationalization.html) fo
 
 ### layout
 
-Layout folder. This folder contains the theme's template files, which define the appearance of your website. Hexo provides the [Swig] template engine by default, but you can easily install additional plugins to support alternative engines such as [EJS], [Haml], [Jade], or [Pug]. Hexo chooses the template engine based on the file extension of the template (just like the posts). For example:
+Layout folder. This folder contains the theme's template files, which define the appearance of your website. Hexo provides the [Nunjucks] template engine by default, but you can easily install additional plugins to support alternative engines such as [EJS], [Haml], [Jade], or [Pug]. Hexo chooses the template engine based on the file extension of the template (just like the posts). For example:
 
 ``` plain
 layout.ejs   - uses EJS
-layout.swig  - uses Swig
+layout.njk   - uses Nunjucks
 ```
 
 See [templates](templates.html) for more info.
@@ -77,8 +77,8 @@ When you have finished building your theme, you can publish it to the [theme lis
 6. Create a pull request and describe the change.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -239,4 +239,4 @@ One possible reason is that there are some unrecognizable words in your file, e.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ko/api/posts.md
+++ b/source/ko/api/posts.md
@@ -58,4 +58,4 @@ hexo.post.render(source, data);
 - [Nunjucks]를 사용하여 렌더링 합니다.
 - `after_post_render` filter를 실행합니다.
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ko/api/tag.md
+++ b/source/ko/api/tag.md
@@ -142,5 +142,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/ko/docs/themes.md
+++ b/source/ko/docs/themes.md
@@ -22,11 +22,11 @@ Hexo theme를 만드는 것은 쉽습니다. - 새로운 폴더를 생성하기�
 
 ### layout
 
-레이아웃 폴더입니다. 이 폴더는 당신의 웹 사이트를 어떻게 보여줄지 정의한 테마 템플릿 파일을 포함합니다. Hexo는 기본적으로 [Swig] 템플릿 엔진을 준비해 두었습니다. 하지만 당신은 [EJS], [Haml], [Jade], [Pug] 등 엔진을 대체할 다른 플러그인을 쉽게 설치할 수 있습니다. Hexo는 템플릿의 파일 확장자를 기반으로 템플릿 엔진을 선택합니다.
+레이아웃 폴더입니다. 이 폴더는 당신의 웹 사이트를 어떻게 보여줄지 정의한 테마 템플릿 파일을 포함합니다. Hexo는 기본적으로 [Nunjucks] 템플릿 엔진을 준비해 두었습니다. 하지만 당신은 [EJS], [Haml], [Jade], [Pug] 등 엔진을 대체할 다른 플러그인을 쉽게 설치할 수 있습니다. Hexo는 템플릿의 파일 확장자를 기반으로 템플릿 엔진을 선택합니다.
 
 ``` plain
 layout.ejs   - uses EJS
-layout.swig  - uses Swig
+layout.njk   - uses Nunjucks
 ```
 
 [templates](templates.html)에서 더 자세한 정보를 확인할 수 있습니다.
@@ -74,8 +74,8 @@ Hexo는 모든 렌더링 가능한 파일들을 처리한 후 `public` 폴더에
 6. 변경사항에 대한 설명을 포함하여 Pull request를 생성합니다.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ko/docs/troubleshooting.md
+++ b/source/ko/docs/troubleshooting.md
@@ -181,4 +181,4 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/pt-br/api/posts.md
+++ b/source/pt-br/api/posts.md
@@ -59,4 +59,4 @@ O argumento `data` deve conter o atributo `content`. Caso não inclua, o Hexo te
 - Renderiza utilizando [Nunjucks]
 - Executa os filtros de `after_post_render`
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/pt-br/api/tag.md
+++ b/source/pt-br/api/tag.md
@@ -143,5 +143,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/pt-br/docs/themes.md
+++ b/source/pt-br/docs/themes.md
@@ -25,11 +25,11 @@ Diretório de idiomas. Veja [internacionalização (i18n)](internationalization.
 
 ### layout
 
-Diretório de layouts. Este diretório contém os arquivos de template do tema, que definem a aparência do seu site. O Hexo fornece o mecanismo de template [Swig] por padrão, mas você pode instalar plugins adicionais para suportar mecanismos alternativos, como [EJS], [Haml], [Jade] ou [Pug]. O Hexo escolhe o mecanismo de template com base na extensão do arquivo deste. Por exemplo:
+Diretório de layouts. Este diretório contém os arquivos de template do tema, que definem a aparência do seu site. O Hexo fornece o mecanismo de template [Nunjucks] por padrão, mas você pode instalar plugins adicionais para suportar mecanismos alternativos, como [EJS], [Haml], [Jade] ou [Pug]. O Hexo escolhe o mecanismo de template com base na extensão do arquivo deste. Por exemplo:
 
 ``` plain
 layout.ejs   - uses EJS
-layout.swig  - uses Swig
+layout.njk   - uses Nunjucks
 ```
 
 Veja [templates](templates.html) para obter mais informações.
@@ -77,8 +77,8 @@ Quando você terminar de criar seu tema, você pode publicá-lo na [lista de tem
 6. Crie um pull request e descreva as mudanças.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/pt-br/docs/troubleshooting.md
+++ b/source/pt-br/docs/troubleshooting.md
@@ -222,4 +222,4 @@ One possible reason is that there are some unrecognizable words in your file, e.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ru/api/posts.md
+++ b/source/ru/api/posts.md
@@ -58,4 +58,4 @@ hexo.post.render(source, data);
 - Обработка [Nunjucks]
 - Постобработка фильтрами `after_post_render`
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ru/api/tag.md
+++ b/source/ru/api/tag.md
@@ -142,5 +142,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/ru/docs/themes.md
+++ b/source/ru/docs/themes.md
@@ -23,11 +23,11 @@ title: Темы
 
 ### layout
 
-Папка шаблонов. Эта папка содержит файлы шаблонов темы, которые определяют внешний вид сайта. Hexo использует шаблонизатор [Swig] по умолчанию, но вы легко сможете установить дополнительные плагины, чтобы поддерживать альтернативные системы, такие как [EJS], [Haml] или [Jade]. Hexo выбирает шаблонизатор на основе расширения файла. Например:
+Папка шаблонов. Эта папка содержит файлы шаблонов темы, которые определяют внешний вид сайта. Hexo использует шаблонизатор [Nunjucks] по умолчанию, но вы легко сможете установить дополнительные плагины, чтобы поддерживать альтернативные системы, такие как [EJS], [Haml] или [Jade]. Hexo выбирает шаблонизатор на основе расширения файла. Например:
 
 ``` plain
 layout.ejs   - uses EJS
-layout.swig  - uses Swig
+layout.njk   - uses Nunjucks
 ```
 
 Дополнительные сведения см. в разделе [шаблоны](templates.html).
@@ -75,7 +75,7 @@ Hexo будет сохранять все обработанные файлы в
 6. Создайте запрос на слияние с описанием изменений.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/ru/docs/troubleshooting.md
+++ b/source/ru/docs/troubleshooting.md
@@ -183,4 +183,4 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/th/api/posts.md
+++ b/source/th/api/posts.md
@@ -58,4 +58,4 @@ Argument | Description
 - Render with [Nunjucks]
 - Execute `after_post_render` filters
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/th/api/tag.md
+++ b/source/th/api/tag.md
@@ -140,5 +140,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/th/docs/themes.md
+++ b/source/th/docs/themes.md
@@ -25,11 +25,11 @@ folder ภาษา สำหรับข้อมูลเพิ่มเติ
 
 ### layout
 
-layout folder. ใน folder นี้มีไฟล์ template ของธีม ซึ่งตั้งค่ารูปลักษณ์ของเว็บไซต์   hexo ใช้ [Swig] เป็น template engine by default แต่คุณเปลี่ยนเป็น engine อื่นๆได้ เช่น [EJS], [Haml], [Jade] หรือ [Pug] hexo เลือก engine ของ template ตาม extension ของไฟล์ ยกตัวอย่างเช่น:
+layout folder. ใน folder นี้มีไฟล์ template ของธีม ซึ่งตั้งค่ารูปลักษณ์ของเว็บไซต์   hexo ใช้ [Nunjucks] เป็น template engine by default แต่คุณเปลี่ยนเป็น engine อื่นๆได้ เช่น [EJS], [Haml], [Jade] หรือ [Pug] hexo เลือก engine ของ template ตาม extension ของไฟล์ ยกตัวอย่างเช่น:
 
 ``` plain
 layout.ejs   - uses EJS
-layout.swig  - uses Swig
+layout.njk   - uses Nunjucks
 ```
 
 สำหรับข้อมูลเพิ่มเติม ไปดูที่ [templates](templates.html)
@@ -84,8 +84,8 @@ hexo จะจัดการและบันทึกไฟล์ทั้ง
 6. Create a pull request and describe the change.
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/th/docs/troubleshooting.md
+++ b/source/th/docs/troubleshooting.md
@@ -269,4 +269,4 @@ One possible reason is that there are some unrecognizable words in your file, e.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-cn/api/posts.md
+++ b/source/zh-cn/api/posts.md
@@ -58,4 +58,4 @@ hexo.post.render(source, data);
 - 使用 [Nunjucks] 渲染
 - 执行 `after_post_render` 过滤器
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-cn/api/tag.md
+++ b/source/zh-cn/api/tag.md
@@ -141,5 +141,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/zh-cn/docs/themes.md
+++ b/source/zh-cn/docs/themes.md
@@ -22,7 +22,7 @@ title: 主题
 
 ### layout
 
-布局文件夹。用于存放主题的模板文件，决定了网站内容的呈现方式，Hexo 内建 [Swig] 模板引擎，您可以另外安装插件来获得 [EJS]、[Haml]、[Jade] 或 [Pug] 支持，Hexo 根据模板文件的扩展名来决定所使用的模板引擎，例如：
+布局文件夹。用于存放主题的模板文件，决定了网站内容的呈现方式，Hexo 内建 [Nunjucks] 模板引擎，您可以另外安装插件来获得 [EJS]、[Haml]、[Jade] 或 [Pug] 支持，Hexo 根据模板文件的扩展名来决定所使用的模板引擎，例如：
 
 ``` plain
 layout.ejs   - 使用 EJS
@@ -74,8 +74,8 @@ layout.swig  - 使用 Swig
 6. 建立一个新的合并申请（pull request）并描述改动。
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-cn/docs/troubleshooting.md
+++ b/source/zh-cn/docs/troubleshooting.md
@@ -186,7 +186,7 @@ $ echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 
 ## EMPERM Error (Windows Subsystem for Linux)
 
@@ -220,4 +220,4 @@ Template render error: (unknown path)
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-tw/api/posts.md
+++ b/source/zh-tw/api/posts.md
@@ -58,4 +58,4 @@ hexo.post.render(source, data);
 - 使用 [Nunjucks] 渲染
 - 執行 `after_post_render` 過濾器
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-tw/api/tag.md
+++ b/source/zh-tw/api/tag.md
@@ -142,5 +142,5 @@ module.exports = hexo => {
 };
 ```
 
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/
 [Swig]: http://paularmstrong.github.io/swig/

--- a/source/zh-tw/docs/themes.md
+++ b/source/zh-tw/docs/themes.md
@@ -22,7 +22,7 @@ title: 主題
 
 ### layout
 
-佈局資料夾。用於放置主題的模板檔案，決定了網站內容的呈現方式，Hexo 內建 [Swig] 模板引擎，您可另外安裝外掛來獲得 [EJS]、[Haml]、[Jade] 或 [Pug] 支援，Hexo 根據模板檔案的副檔名來決定所使用的模板引擎，例如：
+佈局資料夾。用於放置主題的模板檔案，決定了網站內容的呈現方式，Hexo 內建 [Nunjucks] 模板引擎，您可另外安裝外掛來獲得 [EJS]、[Haml]、[Jade] 或 [Pug] 支援，Hexo 根據模板檔案的副檔名來決定所使用的模板引擎，例如：
 
 ``` plain
 EJS: layout.ejs
@@ -74,8 +74,8 @@ Swig: layout.swig
 6. 建立一個新的合併申請（pull request）。
 
 [EJS]: https://github.com/hexojs/hexo-renderer-ejs
-[Swig]: https://github.com/node-swig/swig-templates
 [Haml]: https://github.com/hexojs/hexo-renderer-haml
 [Jade]: https://github.com/hexojs/hexo-renderer-jade
 [Pug]: https://github.com/maxknee/hexo-render-pug
 [hexojs/site]: https://github.com/hexojs/site
+[Nunjucks]: https://mozilla.github.io/nunjucks/

--- a/source/zh-tw/docs/troubleshooting.md
+++ b/source/zh-tw/docs/troubleshooting.md
@@ -176,4 +176,4 @@ One possible reason is that there are some unrecognizable words in your file, e.
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/
-[Nunjucks]: http://mozilla.github.io/nunjucks/
+[Nunjucks]: https://mozilla.github.io/nunjucks/


### PR DESCRIPTION
## What is this PR for?

Hexo has already been changed default renderer.
Change the description of the default renderer from Swig to Nunjucks.

## Check List

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [x] `ko` Korean
  - [x] `pt-br` Brazilian Portuguese
  - [x] `ru` Russian
  - [x] `th` Thai
  - [x] `zh-cn` simplified Chinese
  - [x] `zh-tw` traditional Chinese
