### PR TITLE
docs: add exclude_languages option

### DIFF
--- a/source/docs/syntax-highlight.md
+++ b/source/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,10 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/ko/docs/syntax-highlight.md
+++ b/source/ko/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+  - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,10 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/pt-br/docs/syntax-highlight.md
+++ b/source/pt-br/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,11 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/ru/docs/syntax-highlight.md
+++ b/source/ru/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,11 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/th/docs/syntax-highlight.md
+++ b/source/th/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,11 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/zh-cn/docs/syntax-highlight.md
+++ b/source/zh-cn/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,11 @@ Hexo 通过用 `<figure>` 和 `<table>` 包裹其代码块为其添加了行号�
 ### tab_replace
 
 用代码内的 tab (`\t`) 替换为给定值，默认值是两个空格。
+
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 

--- a/source/zh-tw/docs/syntax-highlight.md
+++ b/source/zh-tw/docs/syntax-highlight.md
@@ -35,6 +35,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: ''
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -81,6 +83,8 @@ highlight:
   auto_detect: false
   line_number: true
   tab_replace: '  '
+  exclude_languages:
+    - example
   wrap: true
   hljs: false
 prismjs:
@@ -131,6 +135,11 @@ You might also notice that all `class` has no `hljs-` prefixed, we will revisit 
 ### tab_replace
 
 Replace tabs inside code block with given string. By default it is 2 spaces.
+
+
+### exclude_languages (+6.1.0)
+
+Only wrap with `<pre><code class="lang"></code></pre>` and will not render all tags(`span`, and `br`) in content if are languages matches this option.
 
 ### wrap
 


### PR DESCRIPTION
refs: https://github.com/hexojs/hexo/pull/3865

## Check List

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [x] `ko` Korean
  - [x] `pt-br` Brazilian Portuguese
  - [x] `ru` Russian
  - [x] `th` Thai
  - [x] `zh-cn` simplified Chinese
  - [x] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
