### PR TITLE
Add plugin: hexo-hash

### DIFF
--- a/source/_data/plugins.yml
+++ b/source/_data/plugins.yml
@@ -1,3 +1,17 @@
+- name: hexo-hash
+  description: 为静态资源创建哈希版本 | Create hash versions for static resources
+  link: https://github.com/Lete114/Hexo-hash
+  tags:
+    - hash
+    - rev
+    - revving
+    - cache
+    - file
+    - files
+    - caching
+    - version
+    - expire
+    - assets
 - name: hexo-seo
   description: Automated Search Engine Optimizations. Sitemap, Schema JSON/LD, Fix Broken Images, Etc. Demo https://www.webmanajemen.com
   link: https://github.com/dimaslanjaka/hexo-seo


### PR DESCRIPTION
- [x] I want to publish my plugin on Hexo official website.
  - [x] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
  - [x] `name` is unique.
  - [x] `link` URL is correct.

Suppose you use the http forced cache, when your static resources change, the user can not get the latest resources, the user can clean the cache to get the latest resources, but this will clean all the cache, the plug-in will generate a hash of the file content to control the version, when the content changes, the url address will change, without cleaning all the cache, you can get the latest resources