### PR TITLE
docs(troubleshooting): add examples of template render error

### DIFF
--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -238,7 +238,7 @@ Template render error: (unknown path)
 Possible cause:
 - There are some unrecognizable words in your file, e.g. invisible zero width characters.
 - Incorrect use or limitation of [tag plugin](/docs/tag-plugins).
-  * Tag plugin is not enclosed with `{% endplugin_name %}`
+  * Block-style tag plugin with content is not enclosed with `{% endplugin_name %}`
   ```
   # Incorrect
   {% codeblock %}

--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -235,7 +235,31 @@ FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/do
 Template render error: (unknown path)
 ```
 
-One possible reason is that there are some unrecognizable words in your file, e.g. invisible zero width characters.
+Possible cause:
+- There are some unrecognizable words in your file, e.g. invisible zero width characters.
+- Incorrect use or limitation of [tag plugin](/docs/tag-plugins).
+  * Tag plugin is not enclosed with `{% endplugin_name %}`
+  ```
+  # Incorrect
+  {% codeblock %}
+  fn()
+  {% codeblock %}
+
+  # Incorrect
+  {% codeblock %}
+  fn()
+
+  # Correct
+  {% codeblock %}
+  fn()
+  {% endcodeblock %}
+  ```
+  * Having Nunjucks-like syntax in a tag plugin, e.g. [`{#`](https://mozilla.github.io/nunjucks/templating.html#comments). A workaround for this example is to use [triple backtick](/docs/tag-plugins#Backtick-Code-Block) instead. [Escape Contents](/docs/troubleshooting#Escape-Contents) section has more details.
+  ```
+  {% codeblock lang:bash %}
+  Size of array is ${#ARRAY}
+  {% endcodeblock %}
+  ```
 
 [Warehouse]: https://github.com/hexojs/warehouse
 [Swig]: http://paularmstrong.github.io/swig/


### PR DESCRIPTION
- some errors are not gracefully handled by [`formatNunjucksError`](https://github.com/hexojs/hexo/blob/bbf09ac00f67a7f943d6be2e473e1242da9383e6/lib/extend/tag.js#L162), hence affected lines are not shown.
- this PR adds some examples of common mistake in using tag plugin.
- related to https://github.com/hexojs/hexo/pull/5031

## Check List

**Please read and check followings before submitting a PR.**

- [ ] I want to publish my theme on Hexo official website.
  - [ ] I have read the [theme publishing doc](https://hexo.io/docs/themes#Publishing).
  - [ ] `name` is unique.
  - [ ] `link` URL is correct.
  - [ ] `preview` URL is correct.
  - [ ] `preview` URL web site is rendered correctly.
  - [ ] Add a screenshot to `source/themes/screenshots`.
  - [ ] Screenshot filename is same as value of `name`.
  - [ ] Screenshot size is `800 * 500`.
  - [ ] Screenshot file format is `png`.
- [ ] I want to publish my plugin on Hexo official website.
  - [ ] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
  - [ ] `name` is unique.
  - [ ] `link` URL is correct.
- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [ ] `en` English
  - [ ] `ko` Korean
  - [ ] `pt-br` Brazilian Portuguese
  - [ ] `ru` Russian
  - [ ] `th` Thai
  - [ ] `zh-cn` simplified Chinese
  - [ ] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
