### PR TITLE
docs: add `(+6.3.0)` mark for an adopted feature in v6.3.0

### DIFF
--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -297,7 +297,7 @@ Check whether the current page is home page.
 <%- is_home() %>
 ```
 
-### is_home_first_page
+### is_home_first_page (+6.3.0)
 
 Check whether the current page is the first of home page.
 
@@ -731,8 +731,8 @@ Option | Description | Default
 `end_color` | End color. You can use hex (`#b700ff`), rgba (`rgba(183, 0, 255, 1)`), hsla (`hsla(283, 100%, 50%, 1)`) or [color keywords]. This option only works when `color` is true. |
 `class` | Class name prefix of tags
 `level` | The number of different class names. This option only works when `class` is set. | 10
-`show_count` | Display the number of posts for each tag | false
-`count_class` | Class name of tag count | count
+`show_count` (+6.3.0) | Display the number of posts for each tag | false
+`count_class` (+6.3.0) | Class name of tag count | count
 
 **Examples:**
 
@@ -768,12 +768,12 @@ Option | Description | Default
 `mid_size` | The number of pages displayed between current page, but not including current page | 2
 `show_all` | Display all pages. If this is set to true, `end_size` and `mid_size` will not work | false
 `escape` | Escape HTML tags | true
-`page_class` | Page class name | `page-number`
-`current_class` | Current page class name | `current`
-`space_class` | Space class name | `space`
-`prev_class` | Previous page class name | `extend prev`
-`next_class` | Next page class name | `extend next`
-`force_prev_next` | Force display previous and next links | false
+`page_class` (+6.3.0) | Page class name | `page-number`
+`current_class` (+6.3.0) | Current page class name | `current`
+`space_class` (+6.3.0) | Space class name | `space`
+`prev_class` (+6.3.0) | Previous page class name | `extend prev`
+`next_class` (+6.3.0) | Next page class name | `extend next`
+`force_prev_next` (+6.3.0) | Force display previous and next links | false
 
 
 **Examples:**
@@ -911,12 +911,12 @@ Parses all heading tags (h1~h6) in the content and inserts a table of contents.
 Option | Description | Default
 --- | --- | ---
 `class` | Class name | `toc`
-`class_item` | Class name of item | `${class}-item`
-`class_link` | Class name of link | `${class}-link`
-`class_text` | Class name of text | `${class}-text`
-`class_child` | Class name of child | `${class}-child`
-`class_number` | Class name of number | `${class}-number`
-`class_level` | Class name prefix of level | `${class}-level`
+`class_item` (+6.3.0) | Class name of item | `${class}-item`
+`class_link` (+6.3.0) | Class name of link | `${class}-link`
+`class_text` (+6.3.0) | Class name of text | `${class}-text`
+`class_child` (+6.3.0) | Class name of child | `${class}-child`
+`class_number` (+6.3.0) | Class name of number | `${class}-number`
+`class_level` (+6.3.0) | Class name prefix of level | `${class}-level`
 `list_number` | Displays list number | true
 `max_depth` | Maximum heading depth of generated toc | 6
 `min_depth` | Minimum heading depth of generated toc | 1

--- a/source/zh-cn/docs/helpers.md
+++ b/source/zh-cn/docs/helpers.md
@@ -291,7 +291,7 @@ url: https://example.com/blog # example
 <%- is_home() %>
 ```
 
-### is_home_first_page
+### is_home_first_page (+6.3.0)
 
 检查当前页面是否为首页的第一页。
 
@@ -724,8 +724,8 @@ Examples:
 `end_color` | 结束的颜色。您可使用十六进位值（`#b700ff`），rgba（`rgba(183, 0, 255, 1)`），hsla（`hsla(283, 100%, 50%, 1)`）或 [颜色关键字]。此变量仅在 `color` 参数开启时才有用。 |
 `class` | 标签的 class name 前缀
 `level` | 不同 class name 的总数。此变量仅在 `class` 参数设定时才有用。 | 10
-`show_count` | 显示每个标签的文章总数 | false
-`count_class` | 标签文章总数的 class | `count`
+`show_count` (+6.3.0) | 显示每个标签的文章总数 | false
+`count_class` (+6.3.0) | 标签文章总数的 class | `count`
 
 ## 其他
 
@@ -752,11 +752,11 @@ Examples:
 `show_all` | 显示所有页数。如果开启此参数的话，`end_size` 和 `mid_size` 就没用了。 | false
 `escape` | Escape HTML tags | true
 `page_class` | 分页链接的 class 名称 | `page-number`
-`current_class` | 当前页链接的 class 名称 | `current`
-`space_class` | 空白文字的 class 名称 | `space`
-`prev_class` | 上一页链接的 class 名称 | `extend prev`
-`next_class` | 下一页链接的 class 名称 | `extend next`
-`force_prev_next` | 强制显示上一页和下一页的链接 | false
+`current_class` (+6.3.0) | 当前页链接的 class 名称 | `current`
+`space_class` (+6.3.0) | 空白文字的 class 名称 | `space`
+`prev_class` (+6.3.0) | 上一页链接的 class 名称 | `extend prev`
+`next_class` (+6.3.0) | 下一页链接的 class 名称 | `extend next`
+`force_prev_next` (+6.3.0) | 强制显示上一页和下一页的链接 | false
 
 **Examples:**
 
@@ -893,11 +893,11 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 参数 | 描述 | 默认值
 --- | --- | ---
 `class` | Class 名称 | `toc`
-`class_item` | 目录元素的 Class 名称 | `${class}-item`
-`class_link` | 目录内链接的 Class 名称 | `${class}-link`
-`class_text` | 目录链接内文本的 Class 名称 | `${class}-text`
-`class_child` | 目录内子列表的 Class 名称 | `${class}-child`
-`class_number` | 目录序号的 Class 名称 | `${class}-number`
+`class_item` (+6.3.0) | 目录元素的 Class 名称 | `${class}-item`
+`class_link` (+6.3.0) | 目录内链接的 Class 名称 | `${class}-link`
+`class_text` (+6.3.0) | 目录链接内文本的 Class 名称 | `${class}-text`
+`class_child` (+6.3.0) | 目录内子列表的 Class 名称 | `${class}-child`
+`class_number` (+6.3.0) | 目录序号的 Class 名称 | `${class}-number`
 `class_level` | 目录层级的 Class 名称前缀 | `${class}-level`
 `list_number` | 显示编号 | true
 `max_depth` | 生成 TOC 的最大深度 | 6


### PR DESCRIPTION
The current `hexo.io` does not support versioning. So, I marked `(+6.3.0)` to new features for `v6.3.0`. Because user can't understand which features are adopted in `6.3.0`. Also I [have already marked `(+6.1.0)` when release `v6.1.0`](https://github.com/yoshinorin/site/commit/c310b62358a36f8f42e2399cc83e97f14f307535) same with this PR.

* refs: https://github.com/hexojs/site/pull/1902
* refs: https://github.com/hexojs/site/pull/1886
* refs: https://github.com/hexojs/site/pull/1885
* refs: https://github.com/hexojs/site/pull/1873

## Check List

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [ ] `ko` Korean
  - [ ] `pt-br` Brazilian Portuguese
  - [ ] `ru` Russian
  - [ ] `th` Thai
  - [ ] `zh-cn` simplified Chinese
  - [x] `zh-tw` traditional Chinese

<!-- 
    Thank you for publishing your work on Hexo site!
    
    If you also would like to become a Hexojs org memeber, here is the opportunity. Simply transfer your repo into Hexojs org, and you will become hexojs member. You could still be the repo admin, but also gain access to hexojs other repoes. 
    
    There are several benefits to do so:
    1. Become Hexojs org member, and gain access to all hexojs repos.
    2. Other Hexojs members could help to maintain issues and review PRs.
    3. More wait you to discover... :)
    
    Please contact hi@abnerchou.me if you are interested in this opportunity.
-->
