### PR TITLE
docs(configuration): fix wrong link

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -23,7 +23,7 @@ Setting | Description | Default
 `root` | The root directory of your website | `url's pathname`
 `permalink` | The [permalink](permalinks.html) format of articles | `:year/:month/:day/:title/`
 `permalink_defaults` | Default values of each segment in permalink |
-`pretty_urls` | Rewrite the [`permalink`](variables.html) variables to pretty URLs |
+`pretty_urls` | Rewrite the [`permalink`](permalinks.html) variables to pretty URLs |
 `pretty_urls.trailing_index` | Trailing `index.html`, set to `false` to remove it  | `true`
 `pretty_urls.trailing_html` | Trailing `.html`, set to `false` to remove it (_does not apply to trailing `index.html`_)  | `true`
 


### PR DESCRIPTION
## Check List

- [ ] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [ ] `ru` Russian
  - [ ] `zh-cn` simplified Chinese
  - [ ] `zh-tw` traditional Chinese


