### PR TITLE
chore(lint-staged): remove `git add`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   },
   "lint-staged": {
     "*.{png,jpeg,jpg,gif,svg}": [
-      "imagemin-lint-staged",
-      "git add"
+      "imagemin-lint-staged"
     ],
     "*.js": "eslint --fix"
   },


### PR DESCRIPTION

from lint-staged v10, `git add` is unnecessary