### PR TITLE
plugin: add hexo-pro

### DIFF
--- a/source/_data/plugins/hexo-pro.yml
+++ b/source/_data/plugins/hexo-pro.yml
@@ -1,0 +1,8 @@
+description: A blog backend for editing blogs
+link: https://github.com/wuzheng228/hexo-pro
+tags:
+  - pro
+  - editor
+  - dashboard
+  - IDE
+  - backend


### PR DESCRIPTION
Add a plugin called hexo pro to the plugin list, which enables hexo to support backend editing and publishing of blogs in server mode