### PR TITLE
docs(helpers/open_graph): Fix incorrect default value and unintended rendering

### DIFF
--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -920,7 +920,7 @@ Inserts [Open Graph] data.
 Option | Description | Default
 --- | --- | ---
 `title` | Page title (`og:title`) | `page.title`
-`type` | Page type (`og:type`) | blog
+`type` | Page type (`og:type`) | article(post page)<br>website(non-post page)
 `url` | Page URL (`og:url`) | `url`
 `image` | Page images (`og:image`) | All images in the content
 `author` | Article author (`og:article:author`) | `config.author`

--- a/source/docs/helpers.md
+++ b/source/docs/helpers.md
@@ -926,7 +926,7 @@ Option | Description | Default
 `author` | Article author (`og:article:author`) | `config.author`
 `date` | Article published time (`og:article:published_time`) | Page published time
 `updated` | Article modified time (`og:article:modified_time`) | Page modified time
-`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Article language (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | Site name (`og:site_name`) | `config.title`
 `description` | Page description (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/ja/docs/helpers.md
+++ b/source/ja/docs/helpers.md
@@ -924,7 +924,7 @@ Google検索フォームを挿入します。
 `author` | 記事の著者 (`og:article:author`) | `config.author`
 `date` | 記事の公開時刻 (`og:article:published_time`) | ページの公開時刻
 `updated` | 記事の更新時刻 (`og:article:modified_time`) | ページの更新時刻
-`language` | 記事の言語 (`og:locale`) | `page.lang || page.language || config.language`
+`language` | 記事の言語 (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | サイト名 (`og:site_name`) | `config.title`
 `description` | ページの説明 (`og:description`) | ページの抜粋またはコンテンツの最初の200文字
 `twitter_card` | Twitter カードタイプ (`twitter:card`) | summary

--- a/source/ja/docs/helpers.md
+++ b/source/ja/docs/helpers.md
@@ -918,7 +918,7 @@ Google検索フォームを挿入します。
 オプション | 説明 | デフォルト
 --- | --- | ---
 `title` | ページタイトル (`og:title`) | `page.title`
-`type` | ページタイプ (`og:type`) | blog
+`type` | ページタイプ (`og:type`) | article（記事ページ）<br>website（記事ページ以外）
 `url` | ページURL (`og:url`) | `url`
 `image` | ページ画像 (`og:image`) | コンテンツ内の全画像
 `author` | 記事の著者 (`og:article:author`) | `config.author`

--- a/source/ko/docs/helpers.md
+++ b/source/ko/docs/helpers.md
@@ -760,7 +760,7 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `author` | Article author (`og:article:author`) | `config.author`
 `date` | Article published time (`og:article:published_time`) | Page published time
 `updated` | Article modified time (`og:article:modified_time`) | Page modified time
-`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Article language (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | 사이트 이름 (`og:site_name`) | `config.title`
 `description` | 페이지 설명 (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/ko/docs/helpers.md
+++ b/source/ko/docs/helpers.md
@@ -754,7 +754,7 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 옵션 | 설명 | 기본 값
 --- | --- | ---
 `title` | 페이지 제목 (`og:title`) | `page.title`
-`type` | 페이지 형태 (`og:type`) | blog
+`type` | 페이지 형태 (`og:type`) | article(post page)<br>website(non-post page)
 `url` | 페이지 URL (`og:url`) | `url`
 `image` | 페이지 커버 (`og:image`) | All images in the content
 `author` | Article author (`og:article:author`) | `config.author`

--- a/source/pt-br/docs/helpers.md
+++ b/source/pt-br/docs/helpers.md
@@ -759,7 +759,7 @@ Insere dados do [Open Graph].
 Opção | Descrição | Padrão
 --- | --- | ---
 `title` | Título da página (`og:title`) | `page.title`
-`type` | Tipo de página (`og:type`) | blog
+`type` | Tipo de página (`og:type`) | article(post page)<br>website(non-post page)
 `url` | URL da página (`og:url`) | `url`
 `image` | Capa da página (`og:image`) | All images in the content
 `author` | Article author (`og:article:author`) | `config.author`

--- a/source/pt-br/docs/helpers.md
+++ b/source/pt-br/docs/helpers.md
@@ -765,7 +765,7 @@ Opção | Descrição | Padrão
 `author` | Article author (`og:article:author`) | `config.author`
 `date` | Article published time (`og:article:published_time`) | Page published time
 `updated` | Article modified time (`og:article:modified_time`) | Page modified time
-`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Article language (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | Nome do site (`og:site_name`) | `config.title`
 `description`| Descrição da página (`og:description`) | Trecho da página ou os 200 primeiros caracteres do conteúdo
 `twitter_card` | Tipo de Twitter card (`twitter:card`) | summary

--- a/source/ru/docs/helpers.md
+++ b/source/ru/docs/helpers.md
@@ -794,7 +794,7 @@ Inserts time tag. `date` can be unix time, ISO string, date object, or [Moment.j
 `author` | Автор статьи (`og:article:author`) | `config.author`
 `date` | Время публикации статьи (`og:article:published_time`) | Время публикации страницы
 `updated` | Время изменения статьи (`og:article:modified_time`) | Время изменения страницы
-`language` | Язык статьи (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Язык статьи (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | Имя сайта (`og:site_name`) | `config.title`
 `description` | Описание страницы (`og:description`) | Отрывок страницы или первые 200 символов содержимого
 `twitter_card` | Карточка Twitter (`twitter:card`) | Краткое изложение

--- a/source/ru/docs/helpers.md
+++ b/source/ru/docs/helpers.md
@@ -788,7 +788,7 @@ Inserts time tag. `date` can be unix time, ISO string, date object, or [Moment.j
 Опция | Описание | Значение по умолчанию
 --- | --- | ---
 `title` | Заголовок страницы (`og:title`) | `page.title`
-`type` | Тип страницы (`og:type`) | blog
+`type` | Тип страницы (`og:type`) | article(post page)<br>website(non-post page)
 `url` | URL-адрес страницы (`og:url`) | `url`
 `image` | Обложка страницы (`og:image`) | Все изображения в материалах
 `author` | Автор статьи (`og:article:author`) | `config.author`

--- a/source/th/docs/helpers.md
+++ b/source/th/docs/helpers.md
@@ -806,7 +806,7 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 Option | Description | Default
 --- | --- | ---
 `title` | Page title (`og:title`) | `page.title`
-`type` | Page type (`og:type`) | blog
+`type` | Page type (`og:type`) | article(post page)<br>website(non-post page)
 `url` | Page URL (`og:url`) | `url`
 `image` | Page images (`og:image`) | All images in the content
 `author` | Article author (`og:article:author`) | `config.author`

--- a/source/th/docs/helpers.md
+++ b/source/th/docs/helpers.md
@@ -812,7 +812,7 @@ Option | Description | Default
 `author` | Article author (`og:article:author`) | `config.author`
 `date` | Article published time (`og:article:published_time`) | Page published time
 `updated` | Article modified time (`og:article:modified_time`) | Page modified time
-`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Article language (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | Site name (`og:site_name`) | `config.title`
 `description` | Page description (`og:description`) | Page excerpt or first 200 characters of the content
 `twitter_card` | Twitter card type (`twitter:card`) | summary

--- a/source/zh-cn/docs/helpers.md
+++ b/source/zh-cn/docs/helpers.md
@@ -902,7 +902,7 @@ url: https://example.com/blog # example
 参数 | 描述 | 默认值
 --- | --- | ---
 `title` | 页面标题 (`og:title`) | `page.title`
-`type` | 页面类型 (`og:type`) | blog
+`type` | 页面类型 (`og:type`) | article(post page)<br>website(non-post page)
 `url` | 页面网址 (`og:url`) | `url`
 `image` | 页面图片 (`og:image`) | 内容中的图片
 `author` | 文章作者 (`og:article:author`) | `config.author`

--- a/source/zh-cn/docs/helpers.md
+++ b/source/zh-cn/docs/helpers.md
@@ -908,7 +908,7 @@ url: https://example.com/blog # example
 `author` | 文章作者 (`og:article:author`) | `config.author`
 `date` | 文章发表时间 (`og:article:published_time`) | 页面发表时间
 `updated` | 文章修改时间 (`og:article:modified_time`) | 页面修改时间
-`language` | 文章语言 (`og:locale`) | `page.lang || page.language || config.language`
+`language` | 文章语言 (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | 网站名称 (`og:site_name`) | `config.title`
 `description` | 页面描述 (`og:description`) | 内容摘要或前 200 字
 `twitter_card` | Twitter 卡片类型 (`twitter:card`) | summary

--- a/source/zh-tw/docs/helpers.md
+++ b/source/zh-tw/docs/helpers.md
@@ -784,7 +784,7 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 `author` | Article author (`og:article:author`) | `config.author`
 `date` | Article published time (`og:article:published_time`) | Page published time
 `updated` | Article modified time (`og:article:modified_time`) | Page modified time
-`language` | Article language (`og:locale`) | `page.lang || page.language || config.language`
+`language` | Article language (`og:locale`) | `page.lang \|\| page.language \|\| config.language`
 `site_name` | 網站名稱 (`og:site_name`) | `config.title`
 `description` | 頁面描述 (`og:description`) | 內容摘要或前 200 字
 `twitter_card` | Twitter 卡片類型 (`twitter:card`) | summary

--- a/source/zh-tw/docs/helpers.md
+++ b/source/zh-tw/docs/helpers.md
@@ -778,7 +778,7 @@ Inserts [generator tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Elemen
 選項 | 描述 | 預設值
 --- | --- | ---
 `title` | 頁面標題 (`og:title`) | `page.title`
-`type` | 頁面類型 (`og:type`) | blog
+`type` | 頁面類型 (`og:type`) | article(post page)<br>website(non-post page)
 `url` | 頁面網址 (`og:url`) | `url`
 `image` | 頁面圖片 (`og:image`) | 內容中的圖片
 `author` | Article author (`og:article:author`) | `config.author`


### PR DESCRIPTION
## Check List

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English
  - [x] `ru` Russian
  - [x] `zh-cn` simplified Chinese
  - [x] `zh-tw` traditional Chinese
  - [x] `ja` Japanese

## Incorrect Default Value

The value `blog` specified as the default value for `og:type` is incorrect. As per the following implementation:

https://github.com/hexojs/hexo/blob/v7.1.1/lib/plugins/helper/open_graph.ts#L82

The default value is `article` or `website` depending on whether it is a post page or not.

## Unintended Rendering


The default value of `og:locale` is chosen from several settings, as implemented below:

> `page.lang || page.language || config.language`

Although this was written in the documentation, the `|` in this code was treated as a table separator, resulting in the display being cut off in the middle. I fixed it by escaping `|`.

Before fix:
![before-fix](https://github.com/hexojs/site/assets/4785040/3a9a8170-ba68-429d-993e-87d7748d937b)

After fix:
![after-fix](https://github.com/hexojs/site/assets/4785040/c9a30204-f127-4558-8606-a4486f966d67)