### PR TITLE
fix: incorrect `canonical` and `alternative` URL annotations

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -81,8 +81,16 @@ hexo.extend.helper.register('header_menu', function(className) {
 });
 
 hexo.extend.helper.register('canonical_url', function(lang) {
-  let path = this.page.path;
-  if (lang && lang !== 'en') path = lang + '/' + path;
+  const slugs = this.page.path.split('/').filter(v => v !== '');
+
+  if (Object.keys(this.site.data.languages).includes(slugs.at(0))) {
+    slugs.shift();
+  }
+  if (lang !== 'en') {
+    slugs.unshift(lang);
+  }
+
+  const path = slugs.join('/');
 
   return full_url_for(path);
 });

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -83,7 +83,7 @@ hexo.extend.helper.register('header_menu', function(className) {
 hexo.extend.helper.register('canonical_url', function(lang) {
   const slugs = this.page.path.split('/').filter(v => v !== '');
 
-  if (Object.keys(this.site.data.languages).includes(slugs.at(0))) {
+  if (Object.keys(this.site.data.languages).includes(slugs[0])) {
     slugs.shift();
   }
   if (lang !== 'en') {

--- a/source/about/index.md
+++ b/source/about/index.md
@@ -1,5 +1,6 @@
 ---
 title: About
+layout: about
 ---
 
 [![github stars](https://img.shields.io/github/stars/hexojs/hexo?style=for-the-badge&color=0e83cd&logo=github)](https://github.com/hexojs/hexo) [![github forks](https://img.shields.io/github/forks/hexojs/hexo?style=for-the-badge&color=0e83cd&logo=github)](https://github.com/hexojs/hexo) [![npm stats](https://img.shields.io/npm/dm/hexo?style=for-the-badge&color=0e83cd&label=npm%20downloads&logo=npm)](https://www.npmjs.com/package/hexo)

--- a/themes/navy/layout/about.njk
+++ b/themes/navy/layout/about.njk
@@ -1,0 +1,1 @@
+{{ partial('page') }}

--- a/themes/navy/layout/partial/head.njk
+++ b/themes/navy/layout/partial/head.njk
@@ -12,6 +12,7 @@
         <link rel="alternative" hreflang="{{ lang }}" href="{{ canonical_url(lang) }}">
       {% endif %}
     {% endfor %}
+    <link rel="alternate" hreflang="x-default" href="{{ canonical_url('en') }}" />
   {% endif %}
   <!-- Icon -->
   <link rel="apple-touch-icon" sizes="57x57" href="{{ url_for('icon/apple-touch-icon-57x57.png') }}">

--- a/themes/navy/layout/partial/head.njk
+++ b/themes/navy/layout/partial/head.njk
@@ -4,7 +4,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Canonical links -->
-  <link rel="canonical" href="{{ page.permalink }}">
+  <link rel="canonical" href="{{ page.permalink | default(canonical_url('en'), true) }}">
   <!-- Alternate links -->
   {% if page.layout == 'page' or page.layout == 'index' %}
     {% for lang, value in site.data.languages %}

--- a/themes/navy/layout/partial/head.njk
+++ b/themes/navy/layout/partial/head.njk
@@ -4,7 +4,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Canonical links -->
-  <link rel="canonical" href="{{ url }}">
+  <link rel="canonical" href="{{ page.permalink }}">
   <!-- Alternative links -->
   {% if page.layout == 'page' or page.layout == 'index' %}
     {% for lang, value in site.data.languages %}

--- a/themes/navy/layout/partial/head.njk
+++ b/themes/navy/layout/partial/head.njk
@@ -8,7 +8,9 @@
   <!-- Alternative links -->
   {% if page.layout == 'page' or page.layout == 'index' %}
     {% for lang, value in site.data.languages %}
-      <link rel="alternative" hreflang="{{ lang }}" href="{{ canonical_url(lang) }}">
+      {% if page.permalink !== canonical_url(lang) %}
+        <link rel="alternative" hreflang="{{ lang }}" href="{{ canonical_url(lang) }}">
+      {% endif %}
     {% endfor %}
   {% endif %}
   <!-- Icon -->

--- a/themes/navy/layout/partial/head.njk
+++ b/themes/navy/layout/partial/head.njk
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Canonical links -->
   <link rel="canonical" href="{{ page.permalink }}">
-  <!-- Alternative links -->
+  <!-- Alternate links -->
   {% if page.layout == 'page' or page.layout == 'index' %}
     {% for lang, value in site.data.languages %}
       {% if page.permalink !== canonical_url(lang) %}
-        <link rel="alternative" hreflang="{{ lang }}" href="{{ canonical_url(lang) }}">
+        <link rel="alternate" hreflang="{{ lang }}" href="{{ canonical_url(lang) }}">
       {% endif %}
     {% endfor %}
     <link rel="alternate" hreflang="x-default" href="{{ canonical_url('en') }}" />


### PR DESCRIPTION
## Check List

- [x] Others (Update, fix, translation, etc...)

## Summary

There is a problem with the `canonical` and `alternative` URL annotations in the `<head>` tag of the page where the translation exists.

This is probably why when we search for "hexo" on Google, we get strange results in some languages.

![search-result-of-google](https://github.com/hexojs/site/assets/4785040/8d1580aa-d57b-482d-9900-4035a4e5ea64)

This pull request provides corrections to errors and improvements in `<head>`, with the aim of displaying search results as naturally as possible.

## Current `<head>` tag

For example, https://hexo.io/zh-tw/api/ outputs the following (excerpt):

```html
<html lang="zh-tw">

<head prefix="og: http://ogp.me/ns#">
  <link rel="canonical" href="https://hexo.io/zh-tw/api/index.html"> 

  <link rel="alternative" hreflang="en" href="https://hexo.io/zh-tw/api/">
  <link rel="alternative" hreflang="zh-tw" href="https://hexo.io/zh-tw/zh-tw/api/">
  <link rel="alternative" hreflang="zh-cn" href="https://hexo.io/zh-cn/zh-tw/api/">
  <!-- ... -->
```

For this example:

* The `canonical` tag does not properly indicate a canonical URL because the `pretty_urls.trailing_index: false` setting means the URL should end with '/'.
* The term `alternative` is incorrect. The correct term is `alternate`.
* The `alternate` tag incorrectly points to URLs with duplicate `:lang` slugs, leading to either nonexistent URLs or URLs that incorrectly display content in English despite indicating a different language.
* `alternative` again points to the URL for the language being displayed (`zh-tw` in this example).

There is a problem as above. In the screenshot at the beginning, it seems that Google is unable to recognize the correspondence between pages in each language, and this is probably the cause.

## Fixes and improvements with this pull request

* Fixed the problem with the `canonical` tag mentioned above. Omit `index.html` at the end.
* Corrected `alternative` to `alternate` above.
* Corrected the error in the URL pointed to by `alternate` above.
* As mentioned above, `alternate` does not output the displayed URL itself.
* `alternative` is output in `/:lang/about/` but the page does not exist. Delete this.
* Annotation with English as default for User Agents in languages for which no translation exists.

As a result of these modifications, the URL annotation will look like this (excerpt):

```html
<html lang="zh-tw">

<head prefix="og: http://ogp.me/ns#">
  <link rel="canonical" href="https://hexo.io/zh-tw/api/">

  <link rel="alternate" hreflang="en" href="https://hexo.io/api/">
  <link rel="alternate" hreflang="zh-cn" href="https://hexo.io/zh-cn/api/">
  <link rel="alternate" hreflang="x-default" href="https://hexo.io/api/" />
  <!-- ... -->
```

```html
<html lang="en">

<head prefix="og: http://ogp.me/ns#">
  <link rel="canonical" href="https://hexo.io/about/">

  <!-- no `alternate` is output -->
  <!-- ... -->
```

## Reference

* [Localized Versions of your Pages | Google Search Central  |  Documentation  |  Google for Developers](https://developers.google.com/search/docs/specialty/international/localized-versions)

> Add `<link rel="alternate" hreflang="lang_code"... >` elements to your page header to tell Google all of the language and region variants of a page. This is useful if you don't have a sitemap or the ability to specify HTTP response headers for your site.

> Consider adding a fallback page for unmatched languages, especially on language/country selectors or auto-redirecting home pages. Use the the x-default value:
> `<link rel="alternate" href="https://example.com/" hreflang="x-default" />`

