### PR TITLE
Add plugin hexo-deployer-s3-hexo6

### DIFF
--- a/source/_data/plugins/hexo-deployer-s3-hexo6.yml
+++ b/source/_data/plugins/hexo-deployer-s3-hexo6.yml
@@ -1,0 +1,6 @@
+description: Amazon S3 deployer plugin for Hexo 6.x.
+link: https://github.com/matian2014/hexo-deployer-s3-hexo6
+tags:
+  - deployer
+  - s3
+  - Hexo 6.x


### PR DESCRIPTION
## Check List

The plugin '[hexo-deployer-s3](https://github.com/nt3rp/hexo-deployer-s3)' can't work with hexo 6.x and the repository has been archived. I upgrade its hexo peerDependencies version to 6.x.

- [x] I want to publish my plugin on Hexo official website.
  - [x] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
  - [x] `name` is unique.
  - [x] `link` URL is correct.
