### PR TITLE
Add plugin hexo-deployer-qiniu-s3

### DIFF
--- a/source/_data/plugins/hexo-deployer-s3-qiniu.yml
+++ b/source/_data/plugins/hexo-deployer-s3-qiniu.yml
@@ -1,0 +1,6 @@
+description: Qiniu S3 deployer plugin for Hexo.
+link: https://github.com/matian2014/hexo-deployer-s3-qiniu
+tags:
+  - deployer
+  - s3
+  - qiniu


### PR DESCRIPTION
## Check List

Add plugin hexo-deployer-qiniu-s3 to sync static pages to [Qiniu](https://www.qiniu.com/)  s3 storage.

- [X] I want to publish my plugin on Hexo official website.
  - [X] I have read the [plugin publishing doc](https://hexo.io/docs/plugins#Publishing).
  - [X] `name` is unique.
  - [X] `link` URL is correct.
