### PR TITLE
docs: fix truncated troubleshooting doc

### DIFF
--- a/source/docs/troubleshooting.md
+++ b/source/docs/troubleshooting.md
@@ -259,7 +259,7 @@ Possible cause:
   {% endcodeblock %}
   ```
 
-  - Having Nunjucks-like syntax in a tag plugin, e.g. [`{#`](https://mozilla.github.io/nunjucks/templating.html#comments). A workaround for this example is to use [triple backtick](/docs/tag-plugins#Backtick-Code-Block) instead. [Escape Contents](/docs/troubleshooting#Escape-Contents) section has more details.
+  - Having Nunjucks-like syntax in a tag plugin, e.g. [`{% raw %} {# {% endraw %}`](https://mozilla.github.io/nunjucks/templating.html#comments). A workaround for this example is to use [triple backtick](/docs/tag-plugins#Backtick-Code-Block) instead. [Escape Contents](/docs/troubleshooting#Escape-Contents) section has more details.
 
   ```
   {% codeblock lang:bash %}


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)
  - Languages:
  - [x] `en` English

## What is for?

The current  troubleshooting doc is truncated.

![truncated](https://github.com/user-attachments/assets/ee48fabd-35e7-42f9-aa56-67a0e1e3655d)


