### PR TITLE
fix(navy): a inexistent stylus variable

### DIFF
--- a/themes/navy/source/css/_partial/page.styl
+++ b/themes/navy/source/css/_partial/page.styl
@@ -185,7 +185,7 @@ note-warn = hsl(0, 100%, 50%)
           content: "—"
           padding: 0 0.3em
         a
-          color: color-grey
+          color: color-gray
   .note
     &.tip
       border-left-color: note-tip


### PR DESCRIPTION
## Check List

**Please read and check followings before submitting a PR.**

- [x] Others (Update, fix, translation, etc...)
  - [x] theme

this var never be defined in `.styl` and could no be complied by stylus. It may be caused by typo.

<img width="508" height="303" alt="image" src="https://github.com/user-attachments/assets/a46b7b03-f98d-4ab0-a347-3c4fd3f12c11" />


https://hexo.io/docs/tag-plugins

<img width="831" height="350" alt="image" src="https://github.com/user-attachments/assets/5c961480-2e42-49c6-8cdb-e17e6ab1d09f" />

