### PR TITLE
Add theme: alpha

### DIFF
--- a/source/_data/themes/alpha.yml
+++ b/source/_data/themes/alpha.yml
@@ -1,0 +1,12 @@
+description: An Apple Newsroom-inspired minimalist theme for Hexo.
+link: https://github.com/zhngymn36181654/hexo-theme-alpha
+preview: https://zhngymn36181654.github.io/blog
+tags:
+  - responsive
+  - clean
+  - white
+  - minimalist
+  - modern
+  - card
+  - Apple
+  - Newsroom


### PR DESCRIPTION
## Summary

Add **alpha** — an Apple Newsroom-inspired minimalist Hexo theme.

### Features
- Apple Newsroom card grid homepage
- Frosted glass navigation with backdrop blur
- Smart archive filters
- Responsive mobile-first design
- i18n ready

### Links
- **Repository:** https://github.com/zhngymn36181654/hexo-theme-alpha
- **Preview:** https://zhngymn36181654.github.io/blog