### PR TITLE
docs(filter): point server_middleware to hexo-server README

### DIFF
--- a/source/api/filter.md
+++ b/source/api/filter.md
@@ -212,15 +212,8 @@ hexo.extend.filter.register("after_clean", function () {
 
 Add middleware to the server. `app` is a [Connect] instance.
 
-For example, to add `X-Powered-By: Hexo` to the response header:
-
-```js
-hexo.extend.filter.register("server_middleware", function (app) {
-  app.use(function (req, res, next) {
-    res.setHeader("X-Powered-By", "Hexo");
-    next();
-  });
-});
-```
+This hook is provided by [hexo-server], not Hexo core, so it only runs when `hexo-server` is installed. See the [hexo-server README] for an implementation example.
 
 [Connect]: https://github.com/senchalabs/connect
+[hexo-server]: https://github.com/hexojs/hexo-server
+[hexo-server README]: https://github.com/hexojs/hexo-server#middleware


### PR DESCRIPTION
Closes #2325.

As noted in #2325, `server_middleware` is provided by hexo-server, not Hexo core, so the example on the `api/filter` page is misleading: it does not run unless hexo-server is installed.

Following the suggestion in the issue, this trims the section to a short note that the filter comes from hexo-server and links to its README for the implementation example. The example itself is added in hexojs/hexo-server#366, so that PR should land first (the README anchor depends on it).

Scope: English page only. The translated pages (ja, ru, zh-cn, zh-tw, pt-br, ko, es, th) still carry the old inline example and can be synced separately.