### PR TITLE
plugin: add hexo-generator-llms to plugin list

### DIFF
--- a/source/_data/plugins/hexo-generator-llms.yml
+++ b/source/_data/plugins/hexo-generator-llms.yml
@@ -1,0 +1,7 @@
+description: Generate an llms.txt index and a Markdown (.md) twin of every page for AI/LLM crawlers.
+link: https://github.com/SSARCandy/hexo-generator-llms
+tags:
+  - generator
+  - llms
+  - seo
+  - ai


### PR DESCRIPTION
Adds [`hexo-generator-llms`](https://github.com/SSARCandy/hexo-generator-llms) to the plugin list.

A generator plugin for GEO (Generative Engine Optimization): it emits a Markdown (`.md`) twin of every page plus an `llms.txt` index for AI/LLM crawlers, and injects `<link rel="alternate" type="text/markdown">` into each page's `<head>` — no theme edits required.

- npm: https://www.npmjs.com/package/hexo-generator-llms
- Repository: https://github.com/SSARCandy/hexo-generator-llms