### PR TITLE
fix(ci): allow checkout of fork PR code in tester workflow

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          allow-unsafe-pr-checkout: true
       - name: Use Node.js
         uses: actions/setup-node@v6
       - name: Install Dependencies


### PR DESCRIPTION
Bumping actions/checkout from v6 to v7 in #2570 made the `tester` workflow fail for all fork PRs because v7 refuses to check out fork PR code under `pull_request_target` by default. This PR sets `allow-unsafe-pr-checkout: true` to restore functionality.